### PR TITLE
Center all windows in WPF UI

### DIFF
--- a/src/NetSparkle.UI.WPF/CheckingForUpdatesWindow.xaml
+++ b/src/NetSparkle.UI.WPF/CheckingForUpdatesWindow.xaml
@@ -13,7 +13,7 @@
         MaxHeight="175"
         Name="CheckingForUpdateWindow"
         d:DesignHeight="300"
-        d:DesignWidth="500">
+        d:DesignWidth="500" WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />

--- a/src/NetSparkle.UI.WPF/DownloadProgressWindow.xaml
+++ b/src/NetSparkle.UI.WPF/DownloadProgressWindow.xaml
@@ -13,7 +13,7 @@
                      SizeToContent="Height"
                      x:Name="DownloadProgressWindowControl"
                      d:DesignHeight="250"
-                     d:DesignWidth="800">
+                     d:DesignWidth="800" WindowStartupLocation="CenterScreen">
     <controls:BaseWindow.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </controls:BaseWindow.Resources>

--- a/src/NetSparkle.UI.WPF/MessageNotificationWindow.xaml
+++ b/src/NetSparkle.UI.WPF/MessageNotificationWindow.xaml
@@ -11,7 +11,7 @@
         ResizeMode="NoResize"
         SizeToContent="Height"
         d:DesignHeight="120"
-        d:DesignWidth="800">
+        d:DesignWidth="800" WindowStartupLocation="CenterScreen">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/src/NetSparkle.UI.WPF/UpdateAvailableWindow.xaml
+++ b/src/NetSparkle.UI.WPF/UpdateAvailableWindow.xaml
@@ -11,7 +11,7 @@
                  MinWidth="450"
                  MinHeight="350"
                  Width="700"
-                 Height="600">
+                 Height="600" WindowStartupLocation="CenterScreen">
     <cont:BaseWindow.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </cont:BaseWindow.Resources>


### PR DESCRIPTION
Getting a lot of complaints about window positioning. Original/macOS version centers the windows when opening them, which seems like a reasonable thing to do on the Windows side too.