### PR TITLE
Use HEAD method instead of GET

### DIFF
--- a/src/NetSparkle/Downloaders/WebClientFileDownloader.cs
+++ b/src/NetSparkle/Downloaders/WebClientFileDownloader.cs
@@ -81,7 +81,11 @@ namespace NetSparkleUpdater.Downloaders
             try
             {
                 using (var response =
-                    await httpClient.GetAsync(item.DownloadLink, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
+                    await httpClient.SendAsync(new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Head,
+                        RequestUri = new Uri(item.DownloadLink)
+                    }))
                 {
                     if (response.IsSuccessStatusCode)
                     {


### PR DESCRIPTION
Previous code used GET and ResponseHeadersRead to interrupt the request as soon as headers were received. This caused an internal ObjectDisposedException due to TlsStream being disposed on return. While this caused no harm on the client code, it causes a connection closed error on the server side, moreover the server allocates buffers to read data which is discarded by the client.
This PR uses HEAD method instead without discarding the response. This is nicer on the server side and avoids internal exception. Performance is the same.
Notice that ContentLength can still be used if required.

Closes #111.