### PR TITLE
changes to generator tool project to allow it to be installed via dot…

### DIFF
--- a/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
+++ b/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
@@ -26,6 +26,9 @@
     <Description>Commandline tool 'generate_appcast.exe' to scan a directory for .exe files and generate appcast.xml</Description>
     <Copyright>Copyright © ndreisg 2019, Deadpikle 2020-2021</Copyright>
     <OutputPath>..\bin\$(Configuration)\NetSparkle.Tools.AppCastGenerator\</OutputPath>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>appcast</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
     <PostBuildEvent />
     <PostBuildEvent />
     <PostBuildEvent />


### PR DESCRIPTION
Make it possible to install on the CLI via dotnet install -g <something>.

Before merging - I've got some questions; 

- seems reasonable to remove the <ToolCommandName> tag, confirm?  So the .exe is installed as generate_appcast.exe - which would match user expectations better.
- should the <PackageOutputPath> be in this change?  

Comments welcome - I'm new to this so please excuse any potentially stupid questions. 