### PR TITLE
AppCastGenerator support for multiple file extensions

### DIFF
--- a/src/NetSparkle.Tools.AppCastGenerator/Program.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/Program.cs
@@ -24,8 +24,8 @@ namespace NetSparkleUpdater.Tools.AppCastGenerator
             [Option('a', "appcast-output-directory", Required = false, HelpText = "Directory to write appcast.xml")]
             public string OutputDirectory { get; set; }
 
-            [Option('e', "ext", SetName = "local", Required = false, HelpText = "Search for file extensions.", Default = "exe")]
-            public string Extension { get; set; }
+            [Option('e', "ext", SetName = "local", Required = false, HelpText = "Search for file extensions.", Default = "exe", Separator = ',')]
+            public IEnumerable<string> Extensions { get; set; }
 
             [Option('b', "binaries", SetName = "local", Required = false, HelpText = "Directory containing binaries.", Default = ".")]
             public string SourceBinaryDirectory { get; set; }
@@ -185,19 +185,18 @@ namespace NetSparkleUpdater.Tools.AppCastGenerator
             }
 
 
-            var search = $"*.{opts.Extension}";
-
             if (opts.SourceBinaryDirectory == ".")
             {
                 opts.SourceBinaryDirectory = Environment.CurrentDirectory;
             }
 
-            var binaries = Directory.GetFiles(opts.SourceBinaryDirectory, search, 
-                opts.SearchBinarySubDirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+            var searches = opts.Extensions.Select(extension => $"*.{extension}");
+            var binaries = searches.SelectMany(search => Directory.GetFiles(opts.SourceBinaryDirectory, search,
+                    opts.SearchBinarySubDirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly));
 
-            if (binaries.Length == 0)
+            if (!binaries.Any())
             {
-                Console.WriteLine($"No files founds matching {search} in {opts.SourceBinaryDirectory}", Color.Yellow);
+                Console.WriteLine($"No files founds matching {string.Join(",", searches)} in {opts.SourceBinaryDirectory}", Color.Yellow);
                 Environment.Exit(1);
             }
 
@@ -216,7 +215,7 @@ namespace NetSparkleUpdater.Tools.AppCastGenerator
             Console.WriteLine("");
             Console.WriteLine($"Operating System: {opts.OperatingSystem}", Color.LightBlue);
             Console.WriteLine($"Searching: {opts.SourceBinaryDirectory}", Color.LightBlue);
-            Console.WriteLine($"Found {binaries.Count()} {opts.Extension} files(s)", Color.LightBlue);
+            Console.WriteLine($"Found {binaries.Count()} {string.Join(",", searches)} files(s)", Color.LightBlue);
             Console.WriteLine("");
 
             try


### PR DESCRIPTION
This change allows to specify multiple binary extensions in AppCastGenerator "-e" option (comma separated). We've recently moved from msi to exe installers and this change was required to support both file extensions when generating the appcast.