### PR TITLE
[AvaloniaUI] Add netstandard2.0 to target frameworks

### DIFF
--- a/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
+++ b/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.UI.Avalonia</PackageId>
     <Version>2.0.5</Version>


### PR DESCRIPTION
Currently it's not possible to use NetSparkle with Mono/.NET Framework based applications that use AvaloniaUI.
This PR adds netstandard2.0 support, which is essentially free here.