### PR TITLE
Set NetSparkle.Samples.NetFramework.WinForms to be High-DPI aware.

### DIFF
--- a/src/NetSparkle.Samples.NetFramework.WinForms/Form1.Designer.cs
+++ b/src/NetSparkle.Samples.NetFramework.WinForms/Form1.Designer.cs
@@ -50,6 +50,8 @@ namespace NetSparkleUpdater.Samples.NetFramework.WinForms
             // 
             // AppBackgroundCheckButton
             // 
+            this.AppBackgroundCheckButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.AppBackgroundCheckButton.Location = new System.Drawing.Point(12, 37);
             this.AppBackgroundCheckButton.Name = "AppBackgroundCheckButton";
             this.AppBackgroundCheckButton.Size = new System.Drawing.Size(212, 23);
@@ -60,6 +62,8 @@ namespace NetSparkleUpdater.Samples.NetFramework.WinForms
             // 
             // ExplicitUserRequestCheckButton
             // 
+            this.ExplicitUserRequestCheckButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.ExplicitUserRequestCheckButton.Location = new System.Drawing.Point(12, 80);
             this.ExplicitUserRequestCheckButton.Name = "ExplicitUserRequestCheckButton";
             this.ExplicitUserRequestCheckButton.Size = new System.Drawing.Size(212, 23);
@@ -70,8 +74,8 @@ namespace NetSparkleUpdater.Samples.NetFramework.WinForms
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(248, 154);
             this.Controls.Add(this.ExplicitUserRequestCheckButton);
             this.Controls.Add(this.AppBackgroundCheckButton);

--- a/src/NetSparkle.Samples.NetFramework.WinForms/NetSparkle.Samples.NetFramework.WinForms.csproj
+++ b/src/NetSparkle.Samples.NetFramework.WinForms/NetSparkle.Samples.NetFramework.WinForms.csproj
@@ -55,6 +55,9 @@
   <PropertyGroup>
     <ApplicationIcon>software-update-available.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -91,6 +94,7 @@
     </Compile>
     <None Include="app.config" />
     <EmbeddedResource Include="NetSparkle_DSA.pub" />
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/NetSparkle.Samples.NetFramework.WinForms/app.config
+++ b/src/NetSparkle.Samples.NetFramework.WinForms/app.config
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+	</startup>
+	<System.Windows.Forms.ApplicationConfigurationSection>
+		<add key="DpiAwareness" value="PerMonitorV2" />
+	</System.Windows.Forms.ApplicationConfigurationSection>
+</configuration>

--- a/src/NetSparkle.Samples.NetFramework.WinForms/app.manifest
+++ b/src/NetSparkle.Samples.NetFramework.WinForms/app.manifest
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization.
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config.
+
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+
+</assembly>


### PR DESCRIPTION
Projects still targeting .NET Framework need to [tell windows they are High-DPI aware](https://docs.microsoft.com/en-us/dotnet/desktop/winforms/high-dpi-support-in-windows-forms?view=netframeworkdesktop-4.8#configuring-your-windows-forms-app-for-high-dpi-support) via some manifest and app.config entries. I've added them to the sample, and the high-DPI forms look just peachy.

This should close #60.

A screenshot after the changes:

![highdps-netsparkle-winforms-netfx](https://user-images.githubusercontent.com/602691/138364419-68de0bf4-8a62-473c-93c5-ffb8822105d1.png)

