### PR TITLE
Minor fix to have --re-parse-existing pass XML content into Parse() i…

### DIFF
--- a/src/NetSparkle.Tools.AppCastGenerator/Program.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/Program.cs
@@ -269,7 +269,7 @@ namespace NetSparkleUpdater.Tools.AppCastGenerator
                 if (opts.ReparseExistingAppCast && File.Exists(appcastFileName))
                 {
                     Console.WriteLine("Parsing existing app cast at {0}...", appcastFileName);
-                    XDocument doc = XDocument.Parse(appcastFileName);
+                    XDocument doc = XDocument.Parse(File.ReadAllText(appcastFileName));
 
                     var docDescendants = doc.Descendants("item");
                     var logWriter = new LogWriter(true);


### PR DESCRIPTION
…nstead of the filename.

Re-tested same (simple) scenarios; works OK and the appcast.xml verifies as well.  