### PR TITLE
Add .NET 6 target to NetSparkle lib

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -29,16 +29,16 @@ jobs:
             5.0.x
             6.0.x
 
-      - name: Run NetSparkle.Tests
+      - name: Run NetSparkle.Tests in .NET 5
         run: dotnet test -f net5 ${{ github.workspace }}/src/NetSparkle.Tests/NetSparkle.Tests.csproj
 
-      - name: Run NetSparkle.Tests.AppCastGenerator
+      - name: Run NetSparkle.Tests.AppCastGenerator in .NET 5
         run: dotnet test -f net5 ${{ github.workspace }}/src/NetSparkle.Tests.AppCastGenerator/NetSparkle.Tests.AppCastGenerator.csproj
 
-      - name: Run NetSparkle.Tests
+      - name: Run NetSparkle.Tests in .NET 6
         run: dotnet test -f net6 ${{ github.workspace }}/src/NetSparkle.Tests/NetSparkle.Tests.csproj
 
-      - name: Run NetSparkle.Tests.AppCastGenerator
+      - name: Run NetSparkle.Tests.AppCastGenerator in .NET 6
         run: dotnet test -f net6 ${{ github.workspace }}/src/NetSparkle.Tests.AppCastGenerator/NetSparkle.Tests.AppCastGenerator.csproj
 
   publish:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -22,16 +22,24 @@ jobs:
       # - name: Add MSBuild to PATH
       #   uses: microsoft/setup-msbuild@v1.0.2
       
-      - name: Setup .NET 5.0 for tests
+      - name: Setup .NET 5.0, 6.0 for tests
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: |
+            5.0.x
+            6.0.x
 
       - name: Run NetSparkle.Tests
         run: dotnet test -f net5 ${{ github.workspace }}/src/NetSparkle.Tests/NetSparkle.Tests.csproj
 
       - name: Run NetSparkle.Tests.AppCastGenerator
         run: dotnet test -f net5 ${{ github.workspace }}/src/NetSparkle.Tests.AppCastGenerator/NetSparkle.Tests.AppCastGenerator.csproj
+
+      - name: Run NetSparkle.Tests
+        run: dotnet test -f net6 ${{ github.workspace }}/src/NetSparkle.Tests/NetSparkle.Tests.csproj
+
+      - name: Run NetSparkle.Tests.AppCastGenerator
+        run: dotnet test -f net6 ${{ github.workspace }}/src/NetSparkle.Tests.AppCastGenerator/NetSparkle.Tests.AppCastGenerator.csproj
 
   publish:
     name: Build and publish all packages to NuGet
@@ -52,13 +60,14 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       
-      - name: Setup .NET 3.0, 3.1, 5.0
+      - name: Setup .NET 3.0, 3.1, 5.0, 6.0
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
             3.0
             3.1.x
             5.0.x
+            6.0.x
           
       - name: Build NetSparkle in Release
         run: dotnet build ${{ github.workspace }}/src/NetSparkle/NetSparkle.csproj --configuration Release

--- a/nuget/winformsnetframework/NetSparkleUpdater.UI.WinForms.NetFramework.nuspec
+++ b/nuget/winformsnetframework/NetSparkleUpdater.UI.WinForms.NetFramework.nuspec
@@ -3,7 +3,7 @@
  <metadata>
    <id>NetSparkleUpdater.UI.WinForms.NetFramework</id>
    <title>NetSparkleUpdater WinForms .NET Framework UI</title>
-   <version>2.0.13-preview20220420001</version>
+   <version>2.1.0-preview20220509001</version>
    <authors>Deadpikle, Dirk Eisenberg</authors>
    <owners>Deadpikle</owners>
    <license type="file">LICENSE.md</license>
@@ -16,10 +16,10 @@
    <description>NetSparkleUpdater/NetSparkle app updater framework with built-in WinForms .NET Framework UI. NetSparkleUpdater/NetSparkle is a C# .NET software update framework that allows you to easily download installer files and update your C# .NET Framework or .NET Core software. Built-in UIs are available for WinForms, WPF, and Avalonia. You provide, somewhere on the internet, an XML appcast with software version information along with release notes in Markdown or HTML format. The NetSparkle framework then checks for an update in the background, displays the release notes to the user, and lets users download or skip the software update. The framework can also perform silent downloads so that you can present all of the UI yourself or set up your own silent software update system, as allowed by your software architecture. It was inspired by the Sparkle (https://sparkle-project.org/) project for Cocoa developers and the WinSparkle (https://winsparkle.org/) project (a Win32 port).</description>
    <copyright>Copyright 2010 - 2022</copyright>
    <tags>Update NetSparkle Sparkle Autoupdate .NET Update WinForms software</tags>    
-   <releaseNotes>2.0 Beta: See https://github.com/NetSparkleUpdater/NetSparkle for all beta information and to file issues/pull requests for and ask questions about this project.</releaseNotes>
+   <releaseNotes>2.0: See https://github.com/NetSparkleUpdater/NetSparkle for all information and to file issues/pull requests for and ask questions about this project.</releaseNotes>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">
-        <dependency id="NetSparkleUpdater.SparkleUpdater" version="2.0.12-preview20220420001" exclude="Build,Analyzers" />
+        <dependency id="NetSparkleUpdater.SparkleUpdater" version="2.1.0-preview20220509001" exclude="Build,Analyzers" />
       </group>
     </dependencies>
  </metadata>

--- a/src/NetSparkle.Samples.Avalonia.MacOS/NetSparkle.Samples.Avalonia.MacOS.csproj
+++ b/src/NetSparkle.Samples.Avalonia.MacOS/NetSparkle.Samples.Avalonia.MacOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <ApplicationIcon>software-update-available.ico</ApplicationIcon>
     <RootNamespace>NetSparkleUpdater.Samples.Avalonia</RootNamespace>
     <AssemblyName>NetSparkleUpdater.Samples.Avalonia</AssemblyName>

--- a/src/NetSparkle.Samples.Avalonia.MacOSZip/NetSparkle.Samples.Avalonia.MacOSZip.csproj
+++ b/src/NetSparkle.Samples.Avalonia.MacOSZip/NetSparkle.Samples.Avalonia.MacOSZip.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <ApplicationIcon>software-update-available.ico</ApplicationIcon>
     <RootNamespace>NetSparkleUpdater.Samples.Avalonia</RootNamespace>
     <AssemblyName>NetSparkleUpdater.Samples.Avalonia</AssemblyName>

--- a/src/NetSparkle.Samples.Avalonia/NetSparkle.Samples.Avalonia.csproj
+++ b/src/NetSparkle.Samples.Avalonia/NetSparkle.Samples.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <ApplicationIcon>software-update-available.ico</ApplicationIcon>
     <RootNamespace>NetSparkleUpdater.Samples.Avalonia</RootNamespace>
     <AssemblyName>NetSparkleUpdater.Samples.Avalonia</AssemblyName>

--- a/src/NetSparkle.Samples.NetCore.WPF/NetSparkle.Samples.NetCore.WPF.csproj
+++ b/src/NetSparkle.Samples.NetCore.WPF/NetSparkle.Samples.NetCore.WPF.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net5-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6-windows;net5-windows;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>software-update-available.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/NetSparkle.Samples.NetCore.WPF/NetSparkle.Samples.NetCore.WPF.csproj
+++ b/src/NetSparkle.Samples.NetCore.WPF/NetSparkle.Samples.NetCore.WPF.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6-windows;net5-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>software-update-available.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/NetSparkle.Samples.NetCore.WinForms/NetSparkle.Samples.NetCore.WinForms.csproj
+++ b/src/NetSparkle.Samples.NetCore.WinForms/NetSparkle.Samples.NetCore.WinForms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5-windows</TargetFramework>
+    <TargetFrameworks>net6-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>software-update-available.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/NetSparkle.Tests.AppCastGenerator/NetSparkle.Tests.AppCastGenerator.csproj
+++ b/src/NetSparkle.Tests.AppCastGenerator/NetSparkle.Tests.AppCastGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFrameworks>net6;net5</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/NetSparkle.Tests/NetSparkle.Tests.csproj
+++ b/src/NetSparkle.Tests/NetSparkle.Tests.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{E50AC3A5-6C63-40D7-A4C4-9B359EFD5707}</ProjectGuid>
     <RootNamespace>NetSparkleUnitTests</RootNamespace>
     <AssemblyName>NetSparkleUnitTests</AssemblyName>
-    <TargetFrameworks>net5;net452</TargetFrameworks>
+    <TargetFrameworks>net6;net5;net452</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
+++ b/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NetSparkleUpdater.AppCastGenerator</RootNamespace>
     <AssemblyName>NetSparkleUpdater.Tools.AppCastGenerator</AssemblyName>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFrameworks>net6;net5</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/src/NetSparkle.Tools.DSAHelper/NetSparkle.Tools.DSAHelper.csproj
+++ b/src/NetSparkle.Tools.DSAHelper/NetSparkle.Tools.DSAHelper.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NetSparkleUpdater.DSAHelper</RootNamespace>
     <AssemblyName>NetSparkleUpdater.Tools.DSAHelper</AssemblyName>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFrameworks>net6;net5</TargetFrameworks>
     <AssemblyTitle>NetSparkle</AssemblyTitle>
     <Product>NetSparkleUpdater.Tools.DSAHelper</Product>
     <Description>Command line tool 'netsparkle-dsa' to generate and use DSA signatures. WARNING: DSA signatures are insecure. If possible, please use NetSparkleUpdater.Tools.AppCastGenerator instead to use ed25519 signatures. Use in conjunction with the NetSparkleUpdater library.</Description>

--- a/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
+++ b/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6;net5;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.UI.Avalonia</PackageId>
-    <Version>2.0.18-preview20220420002</Version>
+    <Version>2.1.0-preview20220509001</Version>
     <Authors>Deadpikle</Authors>
     <Company>Deadpikle</Company>
     <Product>NetSparkleUpdater.UI.Avalonia</Product>

--- a/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
+++ b/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6;net5;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.UI.Avalonia</PackageId>
     <Version>2.0.18-preview20220420002</Version>
@@ -39,6 +39,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6|AnyCPU'">
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6|AnyCPU'">
+		<DefineConstants>TRACE</DefineConstants>
+	</PropertyGroup>
 
   <ItemGroup>
     <None Remove="CheckingForUpdatesWindow.xaml" />

--- a/src/NetSparkle.UI.Avalonia/ViewModels/UpdateAvailableWindowViewModel.cs
+++ b/src/NetSparkle.UI.Avalonia/ViewModels/UpdateAvailableWindowViewModel.cs
@@ -203,7 +203,7 @@ namespace NetSparkleUpdater.UI.Avalonia.ViewModels
             _updates = items;
             var defaultReleaseNotesAvaloniaTemplate = 
                 "<div style=\"border: #ccc 1px solid;\">" + 
-                    "<div style=\"background: {3}; background-color: {3}; font-size: 20px; padding: 5px; padding-top: 10px;\">" + 
+                    "<div style=\"background: {3}; background-color: {3}; font-size: 20px; padding: 5px; padding-top: 4px;\">" + 
                         "{0} ({1})" +
                 "</div><div style=\"padding: 5px; font-size: 16px;\">{2}</div></div>";
             if (string.IsNullOrWhiteSpace(additionalReleaseNotesHeaderHTML)) {

--- a/src/NetSparkle.UI.WPF/NetSparkle.UI.WPF.csproj
+++ b/src/NetSparkle.UI.WPF/NetSparkle.UI.WPF.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/NetSparkleUpdater/NetSparkle.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <AssemblyVersion>2.0.13.0</AssemblyVersion>
-    <Version>2.0.13-preview20220420001</Version>
+    <Version>2.1.0-preview20220509001</Version>
     <PackageIcon>software-update-available.png</PackageIcon>
     <PackageIconUrl />
     <Description>NetSparkleUpdater/NetSparkle app updater framework with built-in WPF .NET Core and .NET Framework UI. NetSparkleUpdater/NetSparkle is a C# .NET software update framework that allows you to easily download installer files and update your C# .NET Framework or .NET Core software. Built-in UIs are available for WinForms, WPF, and Avalonia. You provide, somewhere on the internet, an XML appcast with software version information along with release notes in Markdown or HTML format. The NetSparkle framework then checks for an update in the background, displays the release notes to the user, and lets users download or skip the software update. The framework can also perform silent downloads so that you can present all of the UI yourself or set up your own silent software update system, as allowed by your software architecture. It was inspired by the Sparkle (https://sparkle-project.org/) project for Cocoa developers and the WinSparkle (https://winsparkle.org/) project (a Win32 port).</Description>

--- a/src/NetSparkle.UI.WPF/NetSparkle.UI.WPF.csproj
+++ b/src/NetSparkle.UI.WPF/NetSparkle.UI.WPF.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <ProjectGuid>{6915843C-7947-4268-B569-6F5684651DF4}</ProjectGuid>
-    <TargetFrameworks>net5-windows;netcoreapp3.1;net452</TargetFrameworks>
-    <UseWPF>true</UseWPF>    
+    <UseWPF>true</UseWPF>
+	<TargetFrameworks>net5-windows;net6-windows;netcoreapp3.1;net452</TargetFrameworks>
     <AssemblyTitle>NetSparkleUpdater.UI.WPF</AssemblyTitle>
     <Product>NetSparkleUpdater.UI.WPF</Product>
     <Copyright>Copyright © 2022</Copyright>
@@ -51,15 +51,14 @@
     <ProjectReference Include="..\NetSparkle\NetSparkle.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="System.Drawing.Common">
-      <Version>4.7.1</Version>
-    </PackageReference>
+    <PackageReference Include="System.Drawing.Common" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5-windows'">
-    <PackageReference Include="System.Drawing.Common">
-      <Version>5.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6-windows'">
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+	</ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE.md">
       <Pack>True</Pack>

--- a/src/NetSparkle.UI.WinForms.NetCore/NetSparkle.UI.WinForms.NetCore.csproj
+++ b/src/NetSparkle.UI.WinForms.NetCore/NetSparkle.UI.WinForms.NetCore.csproj
@@ -10,7 +10,7 @@
     <Copyright>Copyright © 2022</Copyright>
     <OutputPath>..\bin\$(Configuration)\NetSparkle.UI.WinForms\</OutputPath>
     <PackageId>NetSparkleUpdater.UI.WinForms.NetCore</PackageId>
-    <Version>2.0.13-preview20220420001</Version>
+    <Version>2.1.0-preview20220509001</Version>
     <Authors>Deadpikle</Authors>
     <Company>Deadpikle</Company>
     <Description>NetSparkleUpdater/NetSparkle app updater framework with built-in WinForms .NET Core UI. NetSparkleUpdater/NetSparkle is a C# .NET software update framework that allows you to easily download installer files and update your C# .NET Framework or .NET Core software. Built-in UIs are available for WinForms, WPF, and Avalonia. You provide, somewhere on the internet, an XML appcast with software version information along with release notes in Markdown or HTML format. The NetSparkle framework then checks for an update in the background, displays the release notes to the user, and lets users download or skip the software update. The framework can also perform silent downloads so that you can present all of the UI yourself or set up your own silent software update system, as allowed by your software architecture. It was inspired by the Sparkle (https://sparkle-project.org/) project for Cocoa developers and the WinSparkle (https://winsparkle.org/) project (a Win32 port).</Description>

--- a/src/NetSparkle.UI.WinForms.NetCore/NetSparkle.UI.WinForms.NetCore.csproj
+++ b/src/NetSparkle.UI.WinForms.NetCore/NetSparkle.UI.WinForms.NetCore.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>NetSparkleUpdater.UI.WinForms</RootNamespace>
     <AssemblyName>NetSparkleUpdater.UI.WinForms</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFrameworks>net5-windows;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5-windows;net6-windows;netcoreapp3.1</TargetFrameworks>
     <AssemblyTitle>NetSparkle.NetFramework.WinForms</AssemblyTitle>
     <Product>NetSparkleUpdater.UI.WinForms.NetCore</Product>
     <Copyright>Copyright © 2022</Copyright>
@@ -158,12 +158,13 @@
     <ProjectReference Include="..\NetSparkle\NetSparkle.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="System.Drawing.Common" Version="4.7.1">
-    </PackageReference>
+	<PackageReference Include="System.Drawing.Common" Version="4.7.1"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5-windows'">
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2">
-    </PackageReference>
+	<PackageReference Include="System.Drawing.Common" Version="5.0.2"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6-windows'">
+	<PackageReference Include="System.Drawing.Common" Version="6.0.0"/>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/NetSparkle/AssemblyAccessors/AssemblyReflectionAccessor.cs
+++ b/src/NetSparkle/AssemblyAccessors/AssemblyReflectionAccessor.cs
@@ -39,9 +39,16 @@ namespace NetSparkleUpdater.AssemblyAccessors
                 {
                     throw new FileNotFoundException();
                 }
-
-                _assembly = Assembly.ReflectionOnlyLoadFrom(absolutePath);
-
+#if NETFRAMEWORK
+                _assembly = Assembly.ReflectionOnlyLoadFrom(absolutePath); // this does not work on .NET Core 2.0+/.NET 5+ and has never worked
+#else
+                // try loading the assembly in ways compliant with .NET Core/.NET 5+
+                _assembly = Assembly.LoadFrom(absolutePath);
+                if (_assembly == null)
+                {
+                    _assembly = Assembly.LoadFile(absolutePath);
+                }
+#endif
                 if (_assembly == null)
                 {
                     throw new ArgumentNullException("Unable to load assembly " + absolutePath);                
@@ -116,7 +123,7 @@ namespace NetSparkleUpdater.AssemblyAccessors
             return null;
         }
 
-        #region Assembly Attribute Accessors
+#region Assembly Attribute Accessors
 
         /// <inheritdoc/>
         public string AssemblyTitle
@@ -176,6 +183,6 @@ namespace NetSparkleUpdater.AssemblyAccessors
                 return a?.Company ?? "";                  
             }
         }
-        #endregion
+#endregion
     }
 }

--- a/src/NetSparkle/Configurations/JSONConfiguration.cs
+++ b/src/NetSparkle/Configurations/JSONConfiguration.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
-#if NETSTANDARD
+#if (NETSTANDARD || NET6)
 using System.Text.Json;
 #endif
 
@@ -138,7 +138,7 @@ namespace NetSparkleUpdater.Configurations
                 try
                 {
                     string json = File.ReadAllText(saveLocation);
-#if NETSTANDARD
+#if (NETSTANDARD || NET6)
                     var data = JsonSerializer.Deserialize<SavedConfigurationData>(json);
 #else
                     var data = JsonConvert.DeserializeObject<SavedConfigurationData>(json);
@@ -201,7 +201,7 @@ namespace NetSparkleUpdater.Configurations
             };
             LastConfigUpdate = savedConfig.LastConfigUpdate;
 
-#if NETSTANDARD
+#if (NETSTANDARD || NET6)
             string json = JsonSerializer.Serialize(savedConfig);
 #else
             string json = JsonConvert.SerializeObject(savedConfig);

--- a/src/NetSparkle/Configurations/RegistryConfiguration.cs
+++ b/src/NetSparkle/Configurations/RegistryConfiguration.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 using Microsoft.Win32;
 using NetSparkleUpdater.AssemblyAccessors;
 using NetSparkleUpdater.Interfaces;
+#if (NETSTANDARD || NET6)
+using System.Runtime.InteropServices;
+#endif
 
 namespace NetSparkleUpdater.Configurations
 {
@@ -135,6 +138,12 @@ namespace NetSparkleUpdater.Configurations
         /// <returns><c>true</c> if the items were loaded successfully; false otherwise</returns>
         private bool LoadValuesFromPath(string regPath)
         {
+#if (NETSTANDARD || NET6)
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return false;
+            }
+#endif
             RegistryKey key = Registry.CurrentUser.OpenSubKey(regPath);
             if (key == null)
             {
@@ -201,6 +210,12 @@ namespace NetSparkleUpdater.Configurations
         /// <returns><c>true</c> if the values were saved to the registry; false otherwise</returns>
         private bool SaveValuesToPath(string regPath)
         {
+#if (NETSTANDARD || NET6)
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return false;
+            }
+#endif
             RegistryKey key = Registry.CurrentUser.CreateSubKey(regPath);
             if (key == null)
             { 

--- a/src/NetSparkle/Downloaders/AsyncHelper.cs
+++ b/src/NetSparkle/Downloaders/AsyncHelper.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation, Inc. All rights reserved.
+// Licensed under the MIT License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NetSparkleUpdater.Downloaders
+{
+    internal static class AsyncHelper
+    {
+        private static readonly TaskFactory _myTaskFactory = new TaskFactory(CancellationToken.None,
+            TaskCreationOptions.None, TaskContinuationOptions.None, TaskScheduler.Default);
+
+        public static TResult RunSync<TResult>(Func<Task<TResult>> func)
+        {
+            var cultureUi = CultureInfo.CurrentUICulture;
+            var culture = CultureInfo.CurrentCulture;
+            return _myTaskFactory.StartNew(() =>
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentUICulture = cultureUi;
+                return func();
+            }).Unwrap().GetAwaiter().GetResult();
+        }
+
+        public static void RunSync(Func<Task> func)
+        {
+            var cultureUi = CultureInfo.CurrentUICulture;
+            var culture = CultureInfo.CurrentCulture;
+            _myTaskFactory.StartNew(() =>
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentUICulture = cultureUi;
+                return func();
+            }).Unwrap().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/NetSparkle/Downloaders/WebClientFileDownloader.cs
+++ b/src/NetSparkle/Downloaders/WebClientFileDownloader.cs
@@ -1,4 +1,5 @@
-﻿using NetSparkleUpdater.Interfaces;
+﻿using NetSparkleUpdater.Events;
+using NetSparkleUpdater.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -6,7 +7,11 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+
+// HttpClient implementation from:
+// https://gist.github.com/xaecors/88e30c3810f8c626f6223ee48ce064bf
 
 namespace NetSparkleUpdater.Downloaders
 {
@@ -17,8 +22,9 @@ namespace NetSparkleUpdater.Downloaders
     /// </summary>
     public class WebClientFileDownloader : IUpdateDownloader, IDisposable
     {
-        private WebClient _webClient;
+        private HttpClient _httpClient;
         private ILogger _logger;
+        private CancellationTokenSource _cts;
 
         /// <summary>
         /// Default constructor for the web client file downloader.
@@ -56,56 +62,26 @@ namespace NetSparkleUpdater.Downloaders
         public void PrepareToDownloadFile()
         {
             _logger?.PrintMessage("IUpdateDownloader: Preparing to download file...");
-            if (_webClient != null)
+            if (_httpClient != null)
             {
-                _logger?.PrintMessage("IUpdateDownloader: WebClient existed already. Canceling...");
-                UnsubscribeFromEvents();
+                _logger?.PrintMessage("IUpdateDownloader: HttpClient existed already. Canceling...");
                 // can't re-use WebClient, so cancel old requests
                 // and start a new request as needed
-                if (_webClient.IsBusy)
+                if (IsDownloading)
                 {
                     try 
                     {
-                        _webClient.CancelAsync();
+                        _httpClient.CancelPendingRequests();
                     } catch {}
                 }
             }
-            _logger?.PrintMessage("IUpdateDownloader: Creating new WebClient...");
-            _webClient = new WebClient
-            {
-                UseDefaultCredentials = true,
-                Proxy = { Credentials = CredentialCache.DefaultNetworkCredentials },
-            };
-            _webClient.DownloadProgressChanged += WebClient_DownloadProgressChanged;
-            _webClient.DownloadFileCompleted += WebClient_DownloadFileCompleted;
-        }
-
-        private void UnsubscribeFromEvents()
-        {
-            if (_webClient != null)
-            {
-                _webClient.DownloadProgressChanged -= WebClient_DownloadProgressChanged;
-                _webClient.DownloadFileCompleted -= WebClient_DownloadFileCompleted;
-            }
-        }
-
-        private void WebClient_DownloadProgressChanged(object sender, DownloadProgressChangedEventArgs e)
-        {
-            DownloadProgressChanged?.Invoke(sender, 
-                new Events.ItemDownloadProgressEventArgs(e.ProgressPercentage, e.UserState, e.BytesReceived, e.TotalBytesToReceive));
-        }
-
-        private void WebClient_DownloadFileCompleted(object sender, AsyncCompletedEventArgs e)
-        {
-            _logger?.PrintMessage("IUpdateDownloader: Download file is complete!");
-            DownloadFileCompleted?.Invoke(sender, e);
+            _logger?.PrintMessage("IUpdateDownloader: Creating new HttpClient...");
+            _cts = new CancellationTokenSource();
+            _httpClient = new HttpClient();
         }
 
         /// <inheritdoc/>
-        public bool IsDownloading
-        {
-            get => _webClient.IsBusy;
-        }
+        public bool IsDownloading { get; private set; }
 
         /// <inheritdoc/>
         public event DownloadProgressEvent DownloadProgressChanged;
@@ -115,24 +91,94 @@ namespace NetSparkleUpdater.Downloaders
         /// <inheritdoc/>
         public void Dispose()
         {
-            UnsubscribeFromEvents();
-            _webClient?.Dispose();
+            _cts.Cancel();
+            _cts.Dispose();
+            _httpClient?.Dispose();
         }
 
         /// <inheritdoc/>
         public void StartFileDownload(Uri uri, string downloadFilePath)
         {
             _logger?.PrintMessage("IUpdateDownloader: Starting file download from {0} to {1}", uri, downloadFilePath);
-            _webClient.DownloadFileAsync(uri, downloadFilePath);
+
+            AsyncHelper.RunSync(async () =>
+            {
+                await StartFileDownloadAsync(uri, downloadFilePath);
+            });
+        }
+
+        private async Task StartFileDownloadAsync(Uri uri, string downloadFilePath)
+        {
+            try
+            {
+                using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri))
+                using (HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _cts.Token))
+                {
+                    if (!response.IsSuccessStatusCode || !response.Content.Headers.ContentLength.HasValue)
+                    {
+                        return;
+                    }
+                    using (FileStream fileStream = new FileStream(downloadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+                    using (Stream contentStream = await response.Content.ReadAsStreamAsync())
+                    {
+                        long totalLength = response.Content.Headers.ContentLength ?? 0;
+                        long totalRead = 0;
+                        long readCount = 0;
+                        byte[] buffer = new byte[8192]; // read 4 KB at a time
+                        UpdateDownloadProgress(0, totalLength);
+                        IsDownloading = true;
+
+                        do
+                        {
+                            if (_cts.IsCancellationRequested)
+                            {
+                                DownloadFileCompleted?.Invoke(this, new AsyncCompletedEventArgs(null, true, null));
+                            }
+
+                            int bytesRead = await contentStream.ReadAsync(buffer, 0, buffer.Length, _cts.Token);
+                            if (bytesRead == 0)
+                            {
+                                UpdateDownloadProgress(totalRead, totalLength);
+                                break;
+                            }
+                            await fileStream.WriteAsync(buffer, 0, bytesRead);
+                            totalRead += bytesRead;
+                            readCount += 1;
+                            if (readCount % 10 != 0)
+                            {
+                                continue;
+                            }
+
+                            UpdateDownloadProgress(totalRead, totalLength);
+                        } while (IsDownloading);
+                        IsDownloading = false;
+                        DownloadFileCompleted?.Invoke(this, new AsyncCompletedEventArgs(null, false, null));
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                LogWriter.PrintMessage("Error: {0}", e.Message);
+                IsDownloading = false;
+                DownloadFileCompleted?.Invoke(this, new AsyncCompletedEventArgs(e, true, null));
+            }
+        }
+
+        private void UpdateDownloadProgress(long totalRead, long totalLength)
+        {
+            int percentage = Convert.ToInt32(Math.Round((double)totalRead / totalLength * 100, 0));
+
+            DownloadProgressChanged?.Invoke(this, new ItemDownloadProgressEventArgs(percentage, null, totalRead, totalLength));
         }
 
         /// <inheritdoc/>
         public void CancelDownload()
         {
             _logger?.PrintMessage("IUpdateDownloader: Canceling download");
-            try 
+            try
             {
-                _webClient.CancelAsync();
+                _cts.Cancel();
+                _httpClient.CancelPendingRequests();
             } catch {}
         }
 

--- a/src/NetSparkle/Downloaders/WebClientFileDownloader.cs
+++ b/src/NetSparkle/Downloaders/WebClientFileDownloader.cs
@@ -144,14 +144,12 @@ namespace NetSparkleUpdater.Downloaders
                             await fileStream.WriteAsync(buffer, 0, bytesRead);
                             totalRead += bytesRead;
                             readCount += 1;
-                            if (readCount % 10 != 0)
-                            {
-                                continue;
-                            }
-
                             UpdateDownloadProgress(totalRead, totalLength);
                         } while (IsDownloading);
                         IsDownloading = false;
+                        fileStream.Close();
+                        contentStream.Close();
+                        UpdateDownloadProgress(totalRead, totalLength);
                         DownloadFileCompleted?.Invoke(this, new AsyncCompletedEventArgs(null, false, null));
                     }
                 }

--- a/src/NetSparkle/Downloaders/WebRequestAppCastDataDownloader.cs
+++ b/src/NetSparkle/Downloaders/WebRequestAppCastDataDownloader.cs
@@ -69,7 +69,6 @@ namespace NetSparkleUpdater.Downloaders
             ServicePointManager.ServerCertificateValidationCallback += ValidateRemoteCertificate;
             // use HttpClient synchronously: https://stackoverflow.com/a/53529122/3938401
             var handler = new HttpClientHandler();
-            handler.Proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
             if (TrustEverySSLConnection)
             {
 #if NETCORE

--- a/src/NetSparkle/NetSparkle.csproj
+++ b/src/NetSparkle/NetSparkle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net6;netstandard2.0;net452</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.SparkleUpdater</PackageId>
     <Version>2.0.12-preview20220420001</Version>
@@ -24,10 +24,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452'">
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
     <OutputPath>..\bin\Release\NetSparkle\</OutputPath>
     <DocumentationFile>..\bin\Release\NetSparkle\NetSparkle.xml</DocumentationFile>
@@ -41,14 +37,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <OutputPath>..\bin\Release\NetSparkle\</OutputPath>
     <DocumentationFile>..\bin\Release\NetSparkle\NetSparkle.xml</DocumentationFile>
-    <DefineConstants>TRACE;NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>TRACE;NETCORE;NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <OutputPath>..\bin\Debug\NetSparkle\</OutputPath>
     <DocumentationFile>..\bin\Debug\NetSparkle\NetSparkle.xml</DocumentationFile>
-    <DefineConstants>DEBUG;TRACE;NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NETCORE;NETSTANDARD</DefineConstants>
   </PropertyGroup>
-  <!-- .NET 4.5 references, compilation flags and build options -->
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6|AnyCPU'">
+		<OutputPath>..\bin\Release\NetSparkle\</OutputPath>
+		<DocumentationFile>..\bin\Release\NetSparkle\NetSparkle.xml</DocumentationFile>
+		<DefineConstants>TRACE;NETCORE;NET6</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6|AnyCPU'">
+		<OutputPath>..\bin\Debug\NetSparkle\</OutputPath>
+		<DocumentationFile>..\bin\Debug\NetSparkle\NetSparkle.xml</DocumentationFile>
+		<DefineConstants>DEBUG;TRACE;NETCORE;NET6</DefineConstants>
+	</PropertyGroup>
+  <!-- .NET 4.5.2 references, compilation flags and build options -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,11 +64,20 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0">
-    </PackageReference>
+	<PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="NSec.Cryptography" Version="20.2.0" />
+	<PackageReference Include="System.Text.Json" Version="6.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6'">
+	<PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />
+	<PackageReference Include="NSec.Cryptography" Version="20.2.0" />
+	<PackageReference Include="System.Text.Json" Version="6.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="nuget\**" />
@@ -78,15 +93,5 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="5.0.2">
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 </Project>

--- a/src/NetSparkle/NetSparkle.csproj
+++ b/src/NetSparkle/NetSparkle.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6;netstandard2.0;net452</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.SparkleUpdater</PackageId>
-    <Version>2.0.12-preview20220420001</Version>
+    <Version>2.1.0-preview20220509001</Version>
     <Authors>Deadpikle, Dirk Eisenberg</Authors>
     <Description>NetSparkleUpdater/NetSparkle is a C# .NET software update framework that allows you to easily download installer files and update your C# .NET Framework or .NET Core software. Built-in UIs are available for WinForms, WPF, and Avalonia; if you want a built-in UI, please reference a NetSparkleUpdater.UI package. You provide, somewhere on the internet, an XML appcast with software version information along with release notes in Markdown or HTML format. The NetSparkle framework then checks for an update in the background, displays the release notes to the user, and lets users download or skip the software update. The framework can also perform silent downloads so that you can present all of the UI yourself or set up your own silent software update system, as allowed by your software architecture. It was inspired by the Sparkle (https://sparkle-project.org/) project for Cocoa developers and the WinSparkle (https://winsparkle.org/) project (a Win32 port).</Description>
     <Copyright>Copyright 2010 - 2022</Copyright>

--- a/src/NetSparkle/NetSparkle.csproj
+++ b/src/NetSparkle/NetSparkle.csproj
@@ -73,7 +73,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6'">
 	<PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />
-	<PackageReference Include="NSec.Cryptography" Version="20.2.0" />
+	<PackageReference Include="NSec.Cryptography" Version="22.4.0" />
 	<PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NetSparkle/ReleaseNotesGrabber.cs
+++ b/src/NetSparkle/ReleaseNotesGrabber.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.IO;
 using NetSparkleUpdater.Enums;
 using System.Net;
+using System.Net.Http;
 
 namespace NetSparkleUpdater
 {
@@ -245,6 +246,7 @@ namespace NetSparkleUpdater
         {
             try
             {
+#if NET452
                 using (var webClient = new WebClient())
                 {
                     webClient.Proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
@@ -258,6 +260,13 @@ namespace NetSparkleUpdater
                     }
                     return await webClient.DownloadStringTaskAsync(Utilities.GetAbsoluteURL(link, sparkle.AppCastUrl));
                 }
+#else
+                var httpClient = new HttpClient();
+                using (cancellationToken.Register(() => httpClient.CancelPendingRequests()))
+                {
+                    return await httpClient.GetStringAsync(link);
+                }
+#endif
             }
             catch (WebException ex)
             {

--- a/src/NetSparkle/SparkleUpdater.cs
+++ b/src/NetSparkle/SparkleUpdater.cs
@@ -19,7 +19,7 @@ using NetSparkleUpdater.AppCastHandlers;
 using NetSparkleUpdater.AssemblyAccessors;
 using System.Text;
 using System.Globalization;
-#if NETSTANDARD
+#if (NETSTANDARD || NET6)
 using System.Runtime.InteropServices;
 #endif
 
@@ -238,7 +238,7 @@ namespace NetSparkleUpdater
             {
                 if (_configuration == null)
                 {
-#if NETSTANDARD
+#if (NETSTANDARD || NET6)
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
                         _configuration = new RegistryConfiguration(new AssemblyReflectionAccessor(_appReferenceAssembly));

--- a/src/NetSparkle/SparkleUpdater.cs
+++ b/src/NetSparkle/SparkleUpdater.cs
@@ -66,6 +66,15 @@ namespace NetSparkleUpdater
 
         private IAppCastHandler _appCastHandler;
 
+        /// <summary>
+        /// The progress window is shown on a separate thread.
+        /// In order to ensure that the download starts after the progress window is shown,
+        /// we create an Action to run after things are ready.
+        /// It would be better if things ran using async/await, but this will
+        /// suffice as a "fix" for now.
+        /// </summary>
+        private Action _actionToRunOnProgressWindowShown;
+
         #endregion
 
         #region Constructors
@@ -855,13 +864,16 @@ namespace NetSparkleUpdater
                     needsToDownload = false;
                     // Still need to set up the ProgressWindow for non-silent downloads, though,
                     // so that the user can actually perform the install
-                    CreateAndShowProgressWindow(item, true);
-                    CallFuncConsideringUIThreads(() => { DownloadFinished?.Invoke(_itemBeingDownloaded, _downloadTempFileName); });
-                    bool shouldInstallAndRelaunch = UserInteractionMode == UserInteractionMode.DownloadAndInstall;
-                    if (shouldInstallAndRelaunch)
+                    _actionToRunOnProgressWindowShown = () =>
                     {
-                        CallFuncConsideringUIThreads(() => { ProgressWindowCompleted(this, new DownloadInstallEventArgs(true)); });
-                    }
+                        CallFuncConsideringUIThreads(() => { DownloadFinished?.Invoke(_itemBeingDownloaded, _downloadTempFileName); });
+                        bool shouldInstallAndRelaunch = UserInteractionMode == UserInteractionMode.DownloadAndInstall;
+                        if (shouldInstallAndRelaunch)
+                        {
+                            CallFuncConsideringUIThreads(() => { ProgressWindowCompleted(this, new DownloadInstallEventArgs(true)); });
+                        }
+                    };
+                    CreateAndShowProgressWindow(item, true);
                 }
                 else if (!_hasAttemptedFileRedownload)
                 {
@@ -897,15 +909,17 @@ namespace NetSparkleUpdater
                 // remove any old event handlers so we don't fire 2x
                 UpdateDownloader.DownloadProgressChanged -= OnDownloadProgressChanged;
                 UpdateDownloader.DownloadFileCompleted -= OnDownloadFinished;
+                _actionToRunOnProgressWindowShown = () =>
+                {
+                    UpdateDownloader.DownloadProgressChanged += OnDownloadProgressChanged;
+                    UpdateDownloader.DownloadFileCompleted += OnDownloadFinished;
 
+                    Uri url = Utilities.GetAbsoluteURL(item.DownloadLink, AppCastUrl);
+                    LogWriter.PrintMessage("Starting to download {0} to {1}", item.DownloadLink, _downloadTempFileName);
+                    UpdateDownloader.StartFileDownload(url, _downloadTempFileName);
+                    CallFuncConsideringUIThreads(() => { DownloadStarted?.Invoke(item, _downloadTempFileName); });
+                };
                 CreateAndShowProgressWindow(item, false);
-                UpdateDownloader.DownloadProgressChanged += OnDownloadProgressChanged;
-                UpdateDownloader.DownloadFileCompleted += OnDownloadFinished;
-
-                Uri url = Utilities.GetAbsoluteURL(item.DownloadLink, AppCastUrl);
-                LogWriter.PrintMessage("Starting to download {0} to {1}", item.DownloadLink, _downloadTempFileName);
-                UpdateDownloader.StartFileDownload(url, _downloadTempFileName);
-                CallFuncConsideringUIThreads(() => { DownloadStarted?.Invoke(item, _downloadTempFileName); });
             }
         }
 
@@ -980,12 +994,16 @@ namespace NetSparkleUpdater
                             {
                                 showSparkleDownloadUI(null);
                                 ProgressWindow?.Show(ShowsUIOnMainThread);
+                                _actionToRunOnProgressWindowShown?.Invoke();
+                                _actionToRunOnProgressWindowShown = null;
                             }, null);
                         }
                         else
                         {
                             showSparkleDownloadUI(null);
                             ProgressWindow?.Show(ShowsUIOnMainThread);
+                            _actionToRunOnProgressWindowShown?.Invoke();
+                            _actionToRunOnProgressWindowShown = null;
                         }
                     });
 #if NETFRAMEWORK


### PR DESCRIPTION
Not fully working yet. Needs testing and more work. The Avalonia UI, at the very least, is not working as the `ProgressWindow` is created after the download finishes, which messes up the process of the UI getting setup properly.

WPF seems to work OK. WinForms works OK. Just Avalonia that is giving me fits on Windows.

Plus unit tests will need fixing. The app cast generator needs to be put onto .NET 5 and 6 (or left out of .NET 6 for now).

Closes #252