### PR TITLE
Fixed command line option --base-uri not working due to Uri parsing

### DIFF
--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -123,7 +123,7 @@ namespace NetSparkle.Tests.AppCastGenerator
                 Extensions = "tar.gz",
                 OutputDirectory = tempDir,
                 OperatingSystem = "windows",
-                BaseUrl = new Uri("https://example.com/downloads"),
+                BaseUrl = "https://example.com/downloads",
                 OverwriteOldItemsInAppcast = false,
                 ReparseExistingAppCast = false,
             };
@@ -400,9 +400,9 @@ namespace NetSparkle.Tests.AppCastGenerator
                 Extensions = "txt",
                 OutputDirectory = tempDir,
                 OperatingSystem = "windows",
-                BaseUrl = new Uri("https://example.com/downloads"),
+                BaseUrl = "https://example.com/downloads",
                 OverwriteOldItemsInAppcast = false,
-                ReparseExistingAppCast = false,                
+                ReparseExistingAppCast = false,
             };
 
             try
@@ -473,9 +473,9 @@ namespace NetSparkle.Tests.AppCastGenerator
                 Extensions = "txt",
                 OutputDirectory = tempDir,
                 OperatingSystem = "windows",
-                BaseUrl = new Uri("https://example.com/downloads"),
+                BaseUrl = "https://example.com/downloads",
                 OverwriteOldItemsInAppcast = false,
-                ReparseExistingAppCast = false,                
+                ReparseExistingAppCast = false,
             };
 
             try
@@ -524,9 +524,9 @@ namespace NetSparkle.Tests.AppCastGenerator
                 Extensions = "txt",
                 OutputDirectory = tempDir,
                 OperatingSystem = "windows",
-                BaseUrl = new Uri("https://example.com/downloads"),
+                BaseUrl = "https://example.com/downloads",
                 OverwriteOldItemsInAppcast = false,
-                ReparseExistingAppCast = false,                
+                ReparseExistingAppCast = false,
             };
 
             try

--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -187,8 +187,8 @@ namespace NetSparkleUpdater.AppCastGenerator
             var itemTitle = string.IsNullOrWhiteSpace(productName) ? productVersion : productName + " " + productVersion;
 
             var urlEncodedFileName = Uri.EscapeDataString(binaryFileInfo.Name);
-            var urlToUse = !string.IsNullOrWhiteSpace(_opts.BaseUrl?.ToString())
-                ? (_opts.BaseUrl.ToString().EndsWith("/") ? _opts.BaseUrl.ToString() : _opts.BaseUrl + "/")
+            var urlToUse = !string.IsNullOrWhiteSpace(_opts.BaseUrl)
+                ? (_opts.BaseUrl.EndsWith("/") ? _opts.BaseUrl : _opts.BaseUrl + "/")
                 : "";
             if (_opts.PrefixVersion)
             {

--- a/src/NetSparkle.Tools.AppCastGenerator/Options.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/Options.cs
@@ -34,8 +34,8 @@ namespace NetSparkleUpdater.AppCastGenerator
         [Option("link-tag", Required = false, HelpText = "Text to put in the app cast <link> tag. Should be your app cast download URL if you use this.", Default = "")]
         public string AppCastLink { get; set; }
 
-        [Option('u', "base-url", SetName = "local", Required = false, HelpText = "Base URL for downloads", Default = null)]
-        public Uri BaseUrl { get; set; }
+        [Option('u', "base-url", SetName = "local", Required = false, HelpText = "Base URL for downloads", Default = "")]
+        public string BaseUrl { get; set; }
 
         [Option('l', "change-log-url", SetName = "local", Required = false, HelpText = "Base URL to the location for your changelog files on " +
             "some server for downloading", Default = "")]


### PR DESCRIPTION
Command line option --base-uri is not working since it can never be parsed as URI if typed in as string in terminal. To fix it, string needs to be used.
Tested on Windows.