### PR TITLE
Add nuget package "Avalonia.Themes.Simple"

### DIFF
--- a/src/NetSparkle.Samples.Avalonia.MacOS/NetSparkle.Samples.Avalonia.MacOS.csproj
+++ b/src/NetSparkle.Samples.Avalonia.MacOS/NetSparkle.Samples.Avalonia.MacOS.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.0-*" />
     <PackageReference Include="Avalonia.Desktop" Version="11.0.0-*" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetSparkle.UI.Avalonia\NetSparkle.UI.Avalonia.csproj" />

--- a/src/NetSparkle.Samples.Avalonia.MacOSZip/NetSparkle.Samples.Avalonia.MacOSZip.csproj
+++ b/src/NetSparkle.Samples.Avalonia.MacOSZip/NetSparkle.Samples.Avalonia.MacOSZip.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.0-*" />
     <PackageReference Include="Avalonia.Desktop" Version="11.0.0-*" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetSparkle.UI.Avalonia\NetSparkle.UI.Avalonia.csproj" />

--- a/src/NetSparkle.Samples.Avalonia/NetSparkle.Samples.Avalonia.csproj
+++ b/src/NetSparkle.Samples.Avalonia/NetSparkle.Samples.Avalonia.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.0-*" />
     <PackageReference Include="Avalonia.Desktop" Version="11.0.0-*" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetSparkle.UI.Avalonia\NetSparkle.UI.Avalonia.csproj" />


### PR DESCRIPTION
"Avalonia.Themes.Simple" package needs to be manually added after version 11, otherwise an error will occur when using the Release mode because it is only referenced by the "Avalonia.Diagnostics" package in Debug mode.
