### PR TITLE
PoC for GetAwaiter().GetResult()

### DIFF
--- a/src/NetSparkle.Samples.DownloadedExe/NetSparkle.Samples.UpdateExe.csproj
+++ b/src/NetSparkle.Samples.DownloadedExe/NetSparkle.Samples.UpdateExe.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SampleDownloadedExecutable</RootNamespace>
     <AssemblyName>NetSparkleUpdate</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/NetSparkle.Samples.NetFramework.WPF/NetSparkle.Samples.NetFramework.WPF.csproj
+++ b/src/NetSparkle.Samples.NetFramework.WPF/NetSparkle.Samples.NetFramework.WPF.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetSparkle.TestAppWPF</RootNamespace>
     <AssemblyName>NetSparkle.TestAppWPF</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/NetSparkle.Samples.NetFramework.WinForms/NetSparkle.Samples.NetFramework.WinForms.csproj
+++ b/src/NetSparkle.Samples.NetFramework.WinForms/NetSparkle.Samples.NetFramework.WinForms.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SampleApplication</RootNamespace>
     <AssemblyName>SampleApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/NetSparkle.Tests/NetSparkle.Tests.csproj
+++ b/src/NetSparkle.Tests/NetSparkle.Tests.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{E50AC3A5-6C63-40D7-A4C4-9B359EFD5707}</ProjectGuid>
     <RootNamespace>NetSparkleUnitTests</RootNamespace>
     <AssemblyName>NetSparkleUnitTests</AssemblyName>
-    <TargetFrameworks>net7.0;net6;net5;net452</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6;net5;net462</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -20,11 +20,11 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
-    <DefineConstants>TRACE;NET452;NETFULL;NETFRAMEWORK</DefineConstants>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
+    <DefineConstants>TRACE;NET462;NETFULL;NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
-    <DefineConstants>DEBUG;TRACE;NET452;NETFULL;NETFRAMEWORK</DefineConstants>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
+    <DefineConstants>DEBUG;TRACE;NET462;NETFULL;NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DefineConstants>TRACE;NETCORE;NETSTANDARD</DefineConstants>

--- a/src/NetSparkle.UI.WPF/NetSparkle.UI.WPF.csproj
+++ b/src/NetSparkle.UI.WPF/NetSparkle.UI.WPF.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{6915843C-7947-4268-B569-6F5684651DF4}</ProjectGuid>
     <UseWPF>true</UseWPF>
-	<TargetFrameworks>net7.0-windows;net5-windows;net6-windows;netcoreapp3.1;net452</TargetFrameworks>
+	<TargetFrameworks>net7.0-windows;net5-windows;net6-windows;netcoreapp3.1;net462</TargetFrameworks>
     <AssemblyTitle>NetSparkleUpdater.UI.WPF</AssemblyTitle>
     <Product>NetSparkleUpdater.UI.WPF</Product>
     <Copyright>Copyright © 2022</Copyright>
@@ -36,7 +36,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
     <DocumentationFile>..\bin\Debug\NetSparkle.UI.WPF\NetSparkle.UI.WPF.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Drawing" />

--- a/src/NetSparkle.UI.WinForms.NetFramework/NetSparkle.UI.WinForms.NetFramework.csproj
+++ b/src/NetSparkle.UI.WinForms.NetFramework/NetSparkle.UI.WinForms.NetFramework.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetSparkleUpdater.UI.WinForms</RootNamespace>
     <AssemblyName>NetSparkleUpdater.UI.WinForms</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/src/NetSparkle/NetSparkle.csproj
+++ b/src/NetSparkle/NetSparkle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6;net5;netstandard2.0;netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6;net5;netstandard2.0;netcoreapp3.1;net462</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.SparkleUpdater</PackageId>
     <Version>2.3.0-preview20230605001</Version>
@@ -24,15 +24,15 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
     <OutputPath>..\bin\Release\NetSparkle\</OutputPath>
     <DocumentationFile>..\bin\Release\NetSparkle\NetSparkle.xml</DocumentationFile>
-    <DefineConstants>TRACE;NET452;NETFULL;NETFRAMEWORK</DefineConstants>
+    <DefineConstants>TRACE;NET462;NETFULL;NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
     <OutputPath>..\bin\Debug\NetSparkle\</OutputPath>
     <DocumentationFile>..\bin\Debug\NetSparkle\NetSparkle.xml</DocumentationFile>
-    <DefineConstants>DEBUG;TRACE;NET452;NETFULL;NETFRAMEWORK</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NET462;NETFULL;NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
 		<OutputPath>..\bin\Release\NetSparkle\</OutputPath>
@@ -85,7 +85,7 @@
 		<DefineConstants>DEBUG;TRACE;NETCORE;NET7</DefineConstants>
 	</PropertyGroup>
   <!-- .NET 4.5.2 references, compilation flags and build options -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/NetSparkle/ReleaseNotesGrabber.cs
+++ b/src/NetSparkle/ReleaseNotesGrabber.cs
@@ -253,7 +253,7 @@ namespace NetSparkleUpdater
         {
             try
             {
-#if NET452
+#if NET462
                 using (var webClient = new WebClient())
                 {
                     webClient.Proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
@@ -281,7 +281,7 @@ namespace NetSparkleUpdater
                 return "";
             }
         }
-#if !NET452
+#if !NET462
 
         /// <summary>
         /// Create the HttpClient used for file downloads


### PR DESCRIPTION
From https://github.com/NetSparkleUpdater/NetSparkle/issues/466#issuecomment-1576785094

I also switched from net452 to net462 for this PoC so I don't have to install the developer pack for an out of support .NET version.

Of note:
* use of GetAwaiter().GetResult()
* removal of .Result access
* ConfigureAwait(false) usage in libraries

Consider this a "sample".

Me not using "var" in front of an await is just a "spleen" to catch mistakes when I forget about the await. That way the compiler will tell me I am stupid.