### PR TITLE
Fix build error of `NetSparkle.Samples.NetFramework.WinForms`

### DIFF
--- a/src/NetSparkle.Samples.NetFramework.WinForms/NetSparkle.Samples.NetFramework.WinForms.csproj
+++ b/src/NetSparkle.Samples.NetFramework.WinForms/NetSparkle.Samples.NetFramework.WinForms.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SampleApplication</RootNamespace>
     <AssemblyName>SampleApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
@@ -57,6 +57,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NetSparkle.Samples.NetFramework.WinForms/app.config
+++ b/src/NetSparkle.Samples.NetFramework.WinForms/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
 	</startup>
 	<System.Windows.Forms.ApplicationConfigurationSection>
 		<add key="DpiAwareness" value="PerMonitorV2" />


### PR DESCRIPTION
1. Moving to .NET Framework 4.6.2 due to:

   `error : Project '..\NetSparkle\NetSparkle.csproj' targets 'net8.0;net7.0;net6.0;netstandard2.0;net462'. It cannot be referenced by a project that targets '.NETFramework,Version=v4.5.2'.`

2. Enable `Auto-generate binding redirects` due to:

   `Consider app.config remapping of assembly "System.Runtime.CompilerServices.Unsafe, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" from Version "4.0.4.1" [] to Version "6.0.0.0" [src\bin\Debug\NetSparkle\net462\System.Runtime.CompilerServices.Unsafe.dll] to solve conflict and get rid of warning.`