### PR TITLE
Async event handlers

### DIFF
--- a/src/NetSparkle.Samples.HandleEventsYourself/MainWindow.xaml.cs
+++ b/src/NetSparkle.Samples.HandleEventsYourself/MainWindow.xaml.cs
@@ -169,9 +169,10 @@ namespace NetSparkleUpdater.Samples.HandleEventsYourself
             await _sparkle.CheckForUpdatesQuietly();
         }
 
-        private void _sparkle_FullUpdate_UpdateDetected(object sender, Events.UpdateDetectedEventArgs e)
+        private Task _sparkle_FullUpdate_UpdateDetected(object sender, Events.UpdateDetectedEventArgs e)
         {
             RunFullUpdateUpdateStatusLabel.Text = "Found update...";
+            return Task.CompletedTask;
         }
 
         private void _sparkle_FullUpdate_StartedDownloading(AppCastItem item, string path)

--- a/src/NetSparkle/NetSparkle.csproj
+++ b/src/NetSparkle/NetSparkle.csproj
@@ -19,6 +19,7 @@
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <RootNamespace>NetSparkleUpdater</RootNamespace>
     <PackageReleaseNotes>See https://github.com/NetSparkleUpdater/NetSparkle/releases for all release information and to file issues/pull requests for this project.</PackageReleaseNotes>
+      <NoWarn>VSTHRD200, VSTHRD100, VSTHRD002, VSTHRD001</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
@@ -100,6 +101,7 @@
     <!--<PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" /> TODO: 3.0 -->
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.9.28" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
 	  <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>

--- a/src/NetSparkle/SparkleUpdater.cs
+++ b/src/NetSparkle/SparkleUpdater.cs
@@ -19,6 +19,7 @@ using NetSparkleUpdater.AppCastHandlers;
 using NetSparkleUpdater.AssemblyAccessors;
 using System.Text;
 using System.Globalization;
+using Microsoft.VisualStudio.Threading;
 #if (NETSTANDARD || NET6 || NET7 || NET8)
 using System.Runtime.InteropServices;
 #endif
@@ -1824,7 +1825,7 @@ namespace NetSparkleUpdater
                 // handling everything.
                 if (UpdateDetected != null)
                 {
-                    await UpdateDetected(this, ev); // event's next action can change, here
+                    await UpdateDetected.InvokeAsync(this, ev); // event's next action can change, here
                     switch (ev.NextAction)
                     {
                         case NextUpdateAction.PerformUpdateUnattended:
@@ -2050,7 +2051,7 @@ namespace NetSparkleUpdater
                                 };
             
                                 if (UpdateDetected != null)
-                                    await UpdateDetected.Invoke(this, ev);
+                                    await UpdateDetected.InvokeAsync(this, ev);
                                 
                                 if (_cancelToken.IsCancellationRequested)
                                 {

--- a/src/NetSparkle/SparkleUpdater.cs
+++ b/src/NetSparkle/SparkleUpdater.cs
@@ -1824,7 +1824,7 @@ namespace NetSparkleUpdater
                 // handling everything.
                 if (UpdateDetected != null)
                 {
-                    UpdateDetected(this, ev); // event's next action can change, here
+                    await UpdateDetected(this, ev); // event's next action can change, here
                     switch (ev.NextAction)
                     {
                         case NextUpdateAction.PerformUpdateUnattended:
@@ -2048,7 +2048,10 @@ namespace NetSparkleUpdater
                                     LatestVersion = updates[0],
                                     AppCastItems = updates
                                 };
-                                UpdateDetected?.Invoke(this, ev);
+            
+                                if (UpdateDetected != null)
+                                    await UpdateDetected.Invoke(this, ev);
+                                
                                 if (_cancelToken.IsCancellationRequested)
                                 {
                                     break;

--- a/src/NetSparkle/SparkleUpdaterEvents.cs
+++ b/src/NetSparkle/SparkleUpdaterEvents.cs
@@ -1,18 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Net;
-using System.Text;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using NetSparkleUpdater.Events;
 
 namespace NetSparkleUpdater
 {
     public partial class SparkleUpdater : IDisposable
     {
         /// <summary>
+        /// Async event handler to allow awaiting of all event handlers.
+        /// </summary>
+        /// <typeparam name="TEventArgs">EventArgs to use with the handler.</typeparam>
+        public delegate Task AsyncEventHandler<TEventArgs>(object sender, TEventArgs e);
+        
+        /// <summary>
         /// This event will be raised when an update check is about to be started
         /// </summary>
         public event LoopStartedOperation LoopStarted;
+        
         /// <summary>
         /// This event will be raised when an update check has finished
         /// </summary>
@@ -22,11 +28,13 @@ namespace NetSparkleUpdater
         /// Called when update check has just begun
         /// </summary>
         public event UpdateCheckStarted UpdateCheckStarted;
+        
         /// <summary>
         /// This event can be used to override the standard user interface
         /// process when an update is detected
         /// </summary>
-        public event UpdateDetected UpdateDetected;
+        public event AsyncEventHandler<UpdateDetectedEventArgs> UpdateDetected;
+        
         /// <summary>
         /// Called when update check is all done. <see cref="UpdateDetected"/> may have been 
         /// called between the start and end of the update check.

--- a/src/NetSparkle/SparkleUpdaterEvents.cs
+++ b/src/NetSparkle/SparkleUpdaterEvents.cs
@@ -2,18 +2,13 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 using NetSparkleUpdater.Events;
 
 namespace NetSparkleUpdater
 {
     public partial class SparkleUpdater : IDisposable
     {
-        /// <summary>
-        /// Async event handler to allow awaiting of all event handlers.
-        /// </summary>
-        /// <typeparam name="TEventArgs">EventArgs to use with the handler.</typeparam>
-        public delegate Task AsyncEventHandler<TEventArgs>(object sender, TEventArgs e);
-        
         /// <summary>
         /// This event will be raised when an update check is about to be started
         /// </summary>


### PR DESCRIPTION
I had a use case for the UpdateDetected event where I wanted to call asynchronous code inside the event handler. With the current code, it doesn't seem possible to call async code within the handler and actually ensure that code finishes executing before SparkleUpdater continues it's normal flow.

I'm proposing in this PR to make SparkleUpdater's events AsyncEventHandlers, so the completion of all handler for each event can be awaited inside the SparkleUpdater code using InvokeAsync. I'm using the implementation provided by the [Microsoft.VisualStudio.Threading package](https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.threading.tplextensions.invokeasync?view=visualstudiosdk-2022#microsoft-visualstudio-threading-tplextensions-invokeasync-1(microsoft-visualstudio-threading-asynceventhandler((-0))-system-object-0)). (This package adds a ton of warnings related to async code, so I set the NoWarn flag for them)

This is a breaking change, as current handlers will now have to return "Task.CompletedTask" since the handlers are expected to return Task instead of void. I'm submitting this as a draft PR with only UpdateDetected converted to AsyncEventHandler. If you agree with this approach, I can convert the remaining events as well.