### PR TITLE
Changelog file name fix 

### DIFF
--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -204,28 +204,37 @@ namespace NetSparkleUpdater.AppCastGenerator
 
             // changelog stuff
             var changelogFileName = productVersion + ".md";
-            var changelogPath = useChangelogs ? Path.Combine(_opts.ChangeLogPath, changelogFileName) : "";
-            var hasChangelogForFile = useChangelogs && File.Exists(changelogPath);
+            var changelogPath = Path.Combine(_opts.ChangeLogPath, changelogFileName);
+            var hasChangelogForFile = File.Exists(changelogPath);
+
+            // If not found, try with the changelog prefix and a space
             if (useChangelogs && !hasChangelogForFile && !string.IsNullOrWhiteSpace(changelogFileNamePrefix))
             {
-                changelogPath = Path.Combine(_opts.ChangeLogPath, changelogFileNamePrefix.Trim() + " " + changelogFileName);
+                changelogFileName = changelogFileNamePrefix.Trim() + " " + productVersion + ".md";
+                changelogPath = Path.Combine(_opts.ChangeLogPath, changelogFileName);
                 hasChangelogForFile = File.Exists(changelogPath);
-                if (!hasChangelogForFile)
-                {
-                    // make one more effort if user doesn't want the space in there
-                    changelogPath = Path.Combine(_opts.ChangeLogPath, changelogFileNamePrefix.Trim() + changelogFileName);
-                    hasChangelogForFile = File.Exists(changelogPath);
-                }
             }
-            // make an additional effort to find the changelog file if they didn't use the file name prefix and used their app's name instead.
+
+            // If still not found, try with the prefix attached directly to the version
             if (useChangelogs && !hasChangelogForFile)
             {
-                changelogPath = Path.Combine(_opts.ChangeLogPath, productName.Trim() + " " + changelogFileName);
+                changelogFileName = changelogFileNamePrefix.Trim() + productVersion + ".md";
+                changelogPath = Path.Combine(_opts.ChangeLogPath, changelogFileName);
                 hasChangelogForFile = File.Exists(changelogPath);
+            }
+
+            // Lastly, try using the product name as the prefix
+            if (useChangelogs && !hasChangelogForFile)
+            {
+                changelogFileName = productName.Trim() + " " + productVersion + ".md";
+                changelogPath = Path.Combine(_opts.ChangeLogPath, changelogFileName);
+                hasChangelogForFile = File.Exists(changelogPath);
+
+                // Try without the space if still not found
                 if (!hasChangelogForFile)
                 {
-                    // make one more last, last ditch effort if user doesn't want the space in there
-                    changelogPath = Path.Combine(_opts.ChangeLogPath, productName.Trim() + changelogFileName);
+                    changelogFileName = productName.Trim() + productVersion + ".md";
+                    changelogPath = Path.Combine(_opts.ChangeLogPath, changelogFileName);
                     hasChangelogForFile = File.Exists(changelogPath);
                 }
             }


### PR DESCRIPTION
The changelog url in the appcast was incorrect and did not include the change log prefix passed by cli. To reproduce:

`netsparkle-generate-appcast -e msi -o windows -n test-f true -u https://test.com -l https://test.com/changelog -p . --change-log-name-prefix "changelog_"`

The appcast will contain:
`<sparkle:releaseNotesLink sparkle:signature="HQ7WFN9CBqgvtjvU17n4gCQ5YHCOf746iC+Praytks3JKez/YHNJ78eaPHTdu0hcXZeTB8EPJHef8ZTFvbAODw==">https://test.com/changelog/1.1.1.md</sparkle:releaseNotesLink>`

Notice how the url doesnt include the prefix and only includes version.md.. This fix resolves this to make the resulting changelog url be ```https://test.com/changelog/changelog_1.1.1.md```