### PR TITLE
Added `SemVerLike` compat to app cast maker

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,7 @@
 * Added `AppCastReducers` helpers for common ways of filtering app cast items (@kenjiuno)
 * Added `SparkleUpdater.InstallUpdateFailed` to see why `InstallUpdate` or its related installer methods fail. Also adds `Enums.InstallUpdateFailureReason`. (fe546de8667b1a5d6e0c4a72a7c128dc954f4aba)
 * `WebFileDownloader.PrepareToDownloadFile` is now `virtual` (84df81122cfae9309de4f5b79489e46287bf3a62)
+* The app cast maker now expects at least `Major.Minor` for version numbers and no longer accepts single digits as version numbers (this fixes things like "My Super App Version 2.exe" having 2 being detected as the version number when the version number is in a prior folder name, and also ensures that the right number is being read)
 
 ## Updating from 0.X or 1.X to 2.X
 

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -1100,7 +1100,6 @@ namespace NetSparkle.Tests.AppCastGenerator
             var buildPath = Directory.CreateDirectory(Path.Combine(tempDir, innerFolder)).FullName;
             try
             {
-                
                 File.WriteAllText(csprojPath, csproj);
                 File.WriteAllText(programPath, program);
                 // compile it
@@ -1123,14 +1122,14 @@ namespace NetSparkle.Tests.AppCastGenerator
                 {
                     if (!string.IsNullOrWhiteSpace(e.Data))
                     {
-                        Console.WriteLine("OUTPUT: " + e.Data);
+                        Console.WriteLine("[Unit test build output] " + e.Data);
                     }
                 };
                 p.ErrorDataReceived += (o, e) => 
                 {
                     if (!string.IsNullOrWhiteSpace(e.Data))
                     {
-                        Console.WriteLine("ERROR: " + e.Data);
+                        Console.WriteLine("[Unit test build output] ERROR: " + e.Data);
                     }
                 };
                 p.Start();
@@ -1176,6 +1175,16 @@ namespace NetSparkle.Tests.AppCastGenerator
                         maker.SerializeItemsToFile(items, productName, appCastFileName);
                         maker.CreateSignatureFile(appCastFileName, opts.SignatureFileExtension ?? "signature");
                     }
+                    Assert.Single(items);
+                    Assert.Equal("2.0.1-beta-1", items[0].Version);
+                    Assert.Equal("2.0.1", items[0].ShortVersion);
+                    Assert.Equal("http://baseURL/appname/changelogs/2.0.1-beta-1.md", items[0].ReleaseNotesLink);
+                    Assert.True(items[0].DownloadSignature.Length > 0);
+                    Assert.True(items[0].IsWindowsUpdate);
+                    Assert.Equal(new FileInfo(dllPath).Length, items[0].UpdateSize);
+                    
+                    // read back and make sure things are the same
+                    (items, productName) = maker.GetItemsAndProductNameFromExistingAppCast(appCastFileName, true);
                     Assert.Single(items);
                     Assert.Equal("2.0.1-beta-1", items[0].Version);
                     Assert.Equal("2.0.1", items[0].ShortVersion);

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -998,6 +998,10 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Equal("2.0", items[1].SemVerLikeVersion.Version);
             Assert.Equal(2337, items[1].UpdateSize);
             Assert.Equal("bar", items[1].DownloadSignature);
+            // make sure things stay in order when sorted (sort with latest first)
+            items.Sort((a, b) => b.SemVerLikeVersion.CompareTo(a.SemVerLikeVersion));
+            Assert.Equal("2.0-beta1", items[0].Version);
+            Assert.Equal("2.0-alpha.1", items[1].Version);
         }
     }
 }

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -97,6 +97,7 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Equal("0.0.0", AppCastMaker.GetVersionFromName("My Favorite Tools (Linux-x64) 0.0.0.tar.gz"));
 
             // Semantic version tests
+            Assert.Equal("3.0.0-beta1", AppCastMaker.GetVersionFromName("MyApp 3.0.0-beta1.exe"));
             // Test cases are from https://github.com/semver/semver/issues/232
             // Valid semantic version tests
             Assert.Equal("0.0.4", AppCastMaker.GetVersionFromName("app 0.0.4.txt"));

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -548,12 +548,12 @@ namespace NetSparkle.Tests.AppCastGenerator
         }
 
         [Fact]
-        public void SingleDigitVersionDoesNotFail()
+        public void SingleMajorMinorDigitVersionDoesNotFail()
         {
             // setup test dir
             var tempDir = GetCleanTempDir();
             // create dummy files
-            var dummyFilePath = Path.Combine(tempDir, "hello 1.0.txt");
+            var dummyFilePath = Path.Combine(tempDir, "hello 1.txt");
             const int fileSizeBytes = 57;
             var tempData = RandomString(fileSizeBytes);
             File.WriteAllText(dummyFilePath, tempData);
@@ -585,7 +585,7 @@ namespace NetSparkle.Tests.AppCastGenerator
                 }
 
                 Assert.Single(items);
-                Assert.Equal("1.0", items[0].Version);
+                Assert.Equal("1", items[0].Version);
                 Assert.Equal("https://example.com/downloads/hello%201.0.txt", items[0].DownloadLink);
                 Assert.True(items[0].DownloadSignature.Length > 0);
                 Assert.True(items[0].IsWindowsUpdate);

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -553,7 +553,7 @@ namespace NetSparkle.Tests.AppCastGenerator
             // setup test dir
             var tempDir = GetCleanTempDir();
             // create dummy files
-            var dummyFilePath = Path.Combine(tempDir, "hello 1.txt");
+            var dummyFilePath = Path.Combine(tempDir, "hello 1.0.txt");
             const int fileSizeBytes = 57;
             var tempData = RandomString(fileSizeBytes);
             File.WriteAllText(dummyFilePath, tempData);
@@ -585,7 +585,7 @@ namespace NetSparkle.Tests.AppCastGenerator
                 }
 
                 Assert.Single(items);
-                Assert.Equal("1", items[0].Version);
+                Assert.Equal("1.0", items[0].Version);
                 Assert.Equal("https://example.com/downloads/hello%201.0.txt", items[0].DownloadLink);
                 Assert.True(items[0].DownloadSignature.Length > 0);
                 Assert.True(items[0].IsWindowsUpdate);

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -70,6 +70,7 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Null(AppCastMaker.GetVersionFromName(null));
             Assert.Null(AppCastMaker.GetVersionFromName("foo"));
             Assert.Null(AppCastMaker.GetVersionFromName("foo1."));
+            Assert.Null(AppCastMaker.GetVersionFromName("hello 1.txt")); // New test, 1 is not a valid version, should be atleast Major.Minor
             Assert.Equal("1.0", AppCastMaker.GetVersionFromName("hello 1.0.txt"));
             Assert.Equal("1.0", AppCastMaker.GetVersionFromName("hello 1.0            .txt")); // whitespace shouldn't matter
             Assert.Null(AppCastMaker.GetVersionFromName("hello 1 .0.txt")); // I changed this to null as I think its a more suitable output versus a version of 0
@@ -77,6 +78,8 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Equal("4.3.2", AppCastMaker.GetVersionFromName("My Favorite App 4.3.2.zip"));
             Assert.Equal("1.0", AppCastMaker.GetVersionFromName("foo1.0"));
             Assert.Equal("0.1", AppCastMaker.GetVersionFromName("foo0.1"));
+            Assert.Equal("0.1", AppCastMaker.GetVersionFromName("foo 0.1"));
+            Assert.Equal("0.1", AppCastMaker.GetVersionFromName("foo_0.1"));
             Assert.Equal("0.1", AppCastMaker.GetVersionFromName("0.1foo"));
             Assert.Equal("0.1", AppCastMaker.GetVersionFromName("0.1 My App"));
             Assert.Equal("0.0.3.1", AppCastMaker.GetVersionFromName("foo0.0.3.1"));
@@ -550,7 +553,7 @@ namespace NetSparkle.Tests.AppCastGenerator
             // setup test dir
             var tempDir = GetCleanTempDir();
             // create dummy files
-            var dummyFilePath = Path.Combine(tempDir, "hello 1.txt");
+            var dummyFilePath = Path.Combine(tempDir, "hello 1.0.txt");
             const int fileSizeBytes = 57;
             var tempData = RandomString(fileSizeBytes);
             File.WriteAllText(dummyFilePath, tempData);
@@ -582,8 +585,8 @@ namespace NetSparkle.Tests.AppCastGenerator
                 }
 
                 Assert.Single(items);
-                Assert.Equal("1", items[0].Version);
-                Assert.Equal("https://example.com/downloads/hello%201.txt", items[0].DownloadLink);
+                Assert.Equal("1.0", items[0].Version);
+                Assert.Equal("https://example.com/downloads/hello%201.0.txt", items[0].DownloadLink);
                 Assert.True(items[0].DownloadSignature.Length > 0);
                 Assert.True(items[0].IsWindowsUpdate);
                 Assert.Equal(fileSizeBytes, items[0].UpdateSize);

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -72,7 +72,7 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Null(AppCastMaker.GetVersionFromName("foo1."));
             Assert.Equal("1.0", AppCastMaker.GetVersionFromName("hello 1.0.txt"));
             Assert.Equal("1.0", AppCastMaker.GetVersionFromName("hello 1.0            .txt")); // whitespace shouldn't matter
-            Assert.Equal("0", AppCastMaker.GetVersionFromName("hello 1 .0.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("hello 1 .0.txt")); // I changed this to null as I think its a more suitable output versus a version of 0
             Assert.Equal("2.3", AppCastMaker.GetVersionFromName("hello a2.3.txt"));
             Assert.Equal("4.3.2", AppCastMaker.GetVersionFromName("My Favorite App 4.3.2.zip"));
             Assert.Equal("1.0", AppCastMaker.GetVersionFromName("foo1.0"));
@@ -92,8 +92,75 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Equal("1.0", AppCastMaker.GetVersionFromName("hello 1.0.tar.gz"));
             Assert.Equal("4.3.2", AppCastMaker.GetVersionFromName("My Favorite App 4.3.2.tar.gz"));
             Assert.Equal("0.0.0", AppCastMaker.GetVersionFromName("My Favorite Tools (Linux-x64) 0.0.0.tar.gz"));
-            // semantic
-            //Assert.Equal("1.1.0", AppCastMaker.GetVersionFromName("1.1.0interruption.1.exe"));
+
+            // Semantic version tests
+            // Test cases are from https://github.com/semver/semver/issues/232
+            // Valid semantic version tests
+            Assert.Equal("0.0.4", AppCastMaker.GetVersionFromName("app 0.0.4.txt"));
+            Assert.Equal("10.20.30", AppCastMaker.GetVersionFromName("app 10.20.30.txt"));
+            Assert.Equal("1.1.2-prerelease+meta", AppCastMaker.GetVersionFromName("app 1.1.2-prerelease+meta.txt"));
+            Assert.Equal("1.1.2+meta", AppCastMaker.GetVersionFromName("app 1.1.2+meta.txt"));
+            Assert.Equal("1.1.2+meta-valid", AppCastMaker.GetVersionFromName("app 1.1.2+meta-valid.txt"));
+            Assert.Equal("1.0.0-alpha", AppCastMaker.GetVersionFromName("app 1.0.0-alpha.txt"));
+            Assert.Equal("1.0.0-beta", AppCastMaker.GetVersionFromName("app 1.0.0-beta.txt"));
+            Assert.Equal("1.0.0-alpha.beta", AppCastMaker.GetVersionFromName("app 1.0.0-alpha.beta.txt"));
+            Assert.Equal("1.0.0-alpha.beta.1", AppCastMaker.GetVersionFromName("app 1.0.0-alpha.beta.1.txt"));
+            Assert.Equal("1.0.0-alpha.1", AppCastMaker.GetVersionFromName("app 1.0.0-alpha.1.txt"));
+            Assert.Equal("1.0.0-alpha0.valid", AppCastMaker.GetVersionFromName("app 1.0.0-alpha0.valid.txt"));
+            Assert.Equal("1.0.0-alpha.0valid", AppCastMaker.GetVersionFromName("app 1.0.0-alpha.0valid.txt"));
+            Assert.Equal("1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay", AppCastMaker.GetVersionFromName("app 1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay.txt"));
+            Assert.Equal("1.0.0-rc.1+build.1", AppCastMaker.GetVersionFromName("app 1.0.0-rc.1+build.1.txt"));
+            Assert.Equal("2.0.0-rc.1+build.123", AppCastMaker.GetVersionFromName("app 2.0.0-rc.1+build.123.txt"));
+            Assert.Equal("1.2.3-beta", AppCastMaker.GetVersionFromName("app 1.2.3-beta.txt"));
+            Assert.Equal("10.2.3-DEV-SNAPSHOT", AppCastMaker.GetVersionFromName("app 10.2.3-DEV-SNAPSHOT.txt"));
+            Assert.Equal("1.2.3-SNAPSHOT-123", AppCastMaker.GetVersionFromName("app 1.2.3-SNAPSHOT-123.txt"));
+            Assert.Equal("1.0.0", AppCastMaker.GetVersionFromName("app 1.0.0.txt"));
+            Assert.Equal("2.0.0", AppCastMaker.GetVersionFromName("app 2.0.0.txt"));
+            Assert.Equal("1.1.7", AppCastMaker.GetVersionFromName("app 1.1.7.txt"));
+            Assert.Equal("2.0.0+build.1848", AppCastMaker.GetVersionFromName("app 2.0.0+build.1848.txt"));
+            Assert.Equal("2.0.1-alpha.1227", AppCastMaker.GetVersionFromName("app 2.0.1-alpha.1227.txt"));
+            Assert.Equal("1.0.0-alpha+beta", AppCastMaker.GetVersionFromName("app 1.0.0-alpha+beta.txt"));
+            Assert.Equal("1.2.3----RC-SNAPSHOT.12.9.1--.12+788", AppCastMaker.GetVersionFromName("app 1.2.3----RC-SNAPSHOT.12.9.1--.12+788.txt"));
+            Assert.Equal("1.2.3----R-S.12.9.1--.12+meta", AppCastMaker.GetVersionFromName("app 1.2.3----R-S.12.9.1--.12+meta.txt"));
+            Assert.Equal("1.2.3----RC-SNAPSHOT.12.9.1--.12", AppCastMaker.GetVersionFromName("app 1.2.3----RC-SNAPSHOT.12.9.1--.12.txt"));
+            Assert.Equal("1.0.0+0.build.1-rc.10000aaa-kk-0.1", AppCastMaker.GetVersionFromName("app 1.0.0+0.build.1-rc.10000aaa-kk-0.1.txt"));
+            Assert.Equal("99999999999999999999999.999999999999999999.99999999999999999", AppCastMaker.GetVersionFromName("app 99999999999999999999999.999999999999999999.99999999999999999.txt"));
+            Assert.Equal("1.0.0-0A.is.legal", AppCastMaker.GetVersionFromName("app 1.0.0-0A.is.legal.txt"));
+
+            // Invalid semantic versions tests
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.2.3-0123.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.2.3-0123.0123.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.1.2+.123.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app +invalid.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app -invalid.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app -invalid+invalid.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app -invalid.01.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app alpha.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app alpha.beta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app alpha.beta.1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app alpha.1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app alpha+beta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app alpha_beta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app alpha..txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app beta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha_beta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app -alpha.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha..txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha..1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha...1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha....1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha.....1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha......1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.0.0-alpha.......1.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.2.3.DEV.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.2-SNAPSHOT.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 1.2-RC-SNAPSHOT.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app -1.0.3-gamma+b7718.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app +justmeta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 9.8.7+meta+meta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 9.8.7-whatever+meta+meta.txt"));
+            Assert.Null(AppCastMaker.GetVersionFromName("app 99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12.txt"));
         }
 
         [Fact]

--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -251,9 +251,7 @@ namespace NetSparkleUpdater.AppCastGenerator
                 Title = itemTitle?.Trim(),
                 DownloadLink = remoteUpdateFile?.Trim(),
                 Version = fullProductVersionString?.Trim(),
-                ShortVersion = productVersionLastDotIndex >= 0 
-                    ? productVersion.Version?.Substring(0, productVersionLastDotIndex)?.Trim() 
-                    : productVersion.Version,
+                ShortVersion = productVersion.Version,
                 PublicationDate = binaryFileInfo.CreationTime,
                 UpdateSize = binaryFileInfo.Length,
                 Description = "",

--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Text.RegularExpressions;
 using NetSparkleUpdater.AppCastHandlers;
 using Console = Colorful.Console;

--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -55,6 +55,7 @@ namespace NetSparkleUpdater.AppCastGenerator
         // Function to check if a segment is a valid version
         private static bool ContainsValidVersionInfo(string segment)
         {
+            // regex from: https://github.com/semver/semver/issues/232
             // Regex for simple version numbers (X.X.X or X.X.X.X)
             string simpleVersionPattern = @"^\d+(\.\d+){1,3}$";
             // Regex for semantic versioning

--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -72,7 +72,7 @@ namespace NetSparkleUpdater.AppCastGenerator
             }
 
             // Handle complex extensions and remove them if they exist
-            string[] extensionPatterns = { @"\.tar\.gz$", @"\.tar$", @"\.gz$", @"\.zip$", @"\.txt$", @"\.exe$", @"\.bin$", @"\.msi$", @"\.excel", @"\.mcdx", @"\.pdf", @"\.dll", @"\.ted" };
+            string[] extensionPatterns = [@"\.tar\.gz$", @"\.tar$", @"\.gz$", @"\.zip$", @"\.txt$", @"\.exe$", @"\.bin$", @"\.msi$", @"\.excel", @"\.mcdx", @"\.pdf", @"\.dll", @"\.ted"];
             foreach (var pattern in extensionPatterns)
             {
                 if (Regex.IsMatch(fullFileNameWithPath, pattern))
@@ -176,25 +176,26 @@ namespace NetSparkleUpdater.AppCastGenerator
                     // For example 0.1foo becomes 0.1, 0.1-foo stays 0.1-foo, 0.1+foo stays 0.1+foo
                     leftPart = RemoveTextBlockFromLeft(leftPart);
 
-                    // Make sure leftpart has a number
+                    // Make sure left part has a number
                     if (Regex.IsMatch(leftPart, @"\d"))
                     {
-                        // Check if its only numeric values and a simple version for quick check
+                        // Check if it has only numeric values and a simple version for quick check
                         if (Regex.IsMatch(leftPart, @"^[\d.]+$") && IsValidVersion(leftPart))
                         {
                             lastValidVersionLeft = leftPart;
                         }
                         else
                         {
-                            // Its more complex so we check if its semantic version before splitting
+                            // It's more complex so we check if its semantic version before splitting
                             if (IsValidVersion(leftPart))
                             {
                                 lastValidVersionLeft = leftPart;
                             }
                             else
                             {
-                                // Start splitting and going from left to right
-                                // Keep record of last applicable version and check one more segment after it, if it fails then the last one we found is what we need
+                                // Start splitting and going from left to right.
+                                // Keep record of last applicable version and check one more segment after it.
+                                // If it fails, then the last one we found is what we need.
                                 var segments = leftPart.Split('.');
                                 string tempSegment = "";
                                 bool lastVersionToCheck = false;
@@ -255,7 +256,8 @@ namespace NetSparkleUpdater.AppCastGenerator
                             else
                             {
                                 // Start splitting and going from left to right
-                                // Keep record of last applicable version and check one more segment after it, if it fails then the last one we found is what we need
+                                // Keep record of last applicable version and check one more segment 
+                                // after it, if it fails, then the last one we found is what we need
                                 var segments = rightPart.Split('.');
                                 string tempSegment = "";
                                 bool lastVersionToCheck = false;
@@ -337,7 +339,14 @@ namespace NetSparkleUpdater.AppCastGenerator
                 : GetVersionFromAssembly(binaryFileInfo.FullName);
             if (productVersion == null)
             {
-                Console.WriteLine($"Unable to determine version of binary {binaryFileInfo.Name}, try --file-extract-version parameter to determine version from file name", Color.Red);
+                if (useFileNameForVersion)
+                {
+                    Console.WriteLine($"Unable to determine version of binary {binaryFileInfo.Name}; please make sure you have at least Major.Minor as a version number and not just one single digit", Color.Red);
+                }
+                else
+                {
+                    Console.WriteLine($"Unable to determine version of binary {binaryFileInfo.Name}; try --file-extract-version parameter to determine version from file name", Color.Red);
+                }
             }
             return productVersion;
         }

--- a/src/NetSparkle/AppCastItem.cs
+++ b/src/NetSparkle/AppCastItem.cs
@@ -12,6 +12,9 @@ namespace NetSparkleUpdater
     [Serializable]
     public class AppCastItem : IComparable<AppCastItem>
     {
+        private SemVerLike _semVerLikeCache;
+        private string _version;
+
         /// <summary>
         /// The application name
         /// </summary>
@@ -27,13 +30,24 @@ namespace NetSparkleUpdater
         /// <summary>
         /// The available version
         /// </summary>
-        public string Version { get; set; }
+        public string Version 
+        { 
+            get => _version; 
+            set { _semVerLikeCache = null; _version = value;} 
+        }
         /// <summary>
         /// The available version as a SemVerLike object (handles things like 1.2-alpha1)
         /// </summary>
         public SemVerLike SemVerLikeVersion
         {
-            get => SemVerLike.Parse(Version);
+            get 
+            {
+                if (_semVerLikeCache == null)
+                {
+                    _semVerLikeCache = SemVerLike.Parse(Version);
+                }
+                return _semVerLikeCache;
+            }
         }
         /// <summary>
         /// Shortened version


### PR DESCRIPTION
Tries to get `SemVerLike` compat into the app cast generator

* [x] Works for assembly versions
* [x] Works for manual `--file-version`
* [x] Fix comparisons so everything looks at `SemVerLike` objects
* [x] Add unit tests
* [x] Add unit tests that read off assembly version (how can we do this with unit tests when this requires a compiled binary...? probably need to do some `Mock` sort of something here.)
* [x] In the `CanMakeAppCastWithAssemblyData` unit test, read in the app cast from disk and make sure it reads things in properly.
* [x] Add parsing of file names off disk for `SemVerLike` so you can have `MyApp 1.0-beta1.exe` on disk and it parses correctly without breaking any of the old parsing methods (may require an additional flag if not backwards compat)
    * Right now `1.1.0-beta.1` parses to `1.1.0.1`