### PR TITLE
Update BouncyCastle to 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Built-in supported update download types:
 ## Getting Started
 
 - [Installing NetSparkle](#installing-netsparkle)
+- [Trimming Your Application](#trimming-your-application)
 - [How Updates Work](#how-updates-work)
 - [Basic Usage](#basic-usage)
 - [App Cast](#app-cast)
@@ -55,6 +56,16 @@ NetSparkle is available via NuGet. To choose a NuGet package to use:
 Quick info for tool installations:
 * App cast generator -- `dotnet tool install --global NetSparkleUpdater.Tools.AppCastGenerator`; available as `netsparkle-generate-appcast` on your command line after installation
 * DSA Helper -- `dotnet tool install --global NetSparkleUpdater.Tools.DSAHelper`; available as `netsparkle-dsa` on your command line after installation
+
+## Trimming your application
+
+[Trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options) is a great way to reduce the file size of your application when it is self-published and/or built as a self-contained application. In short, trimming removes unused code from your applications, including external libraries, so you can ship your application with a reduced file size. To trim your application on publish, add `<PublishTrimmed>true</PublishTrimmed>` to your `csproj` file. If you want to trim all assemblies (including those that may not have specified they are compatible with trimming), add `<TrimMode>full</TrimMode>` to your `csproj` file; to only trim those that have opted-in, use `<TrimMode>partial</TrimMode>`. To enable warnings for trimming, add `<SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>`.
+
+There are other options to use, which you can learn more about on Microsoft's documentation [here](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options). For those applications that may not work with the built-in trimming options, please try [Zack.DotNetTrimmer](https://github.com/yangzhongke/Zack.DotNetTrimmer) or other solutions you may find.
+
+We recommend that you trim your application before publishing it and distributing it to your users. Some of NetSparkle's default dependencies are rather large, but the file size can be drastically reduced by the trim process. If you choose to trim your application, don't forget to test it after trimming and make sure you fix any warnings that come up! And, in particular, if you wish to reduce the size of NetSparkle's BouncyCastle dependency, you can feel free to trim the library on your own (e.g. via a quick sample project as [outlined here](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#show-all-warnings-with-test-app)) and then replace the DLL that NetSparkle ships with with the one you built — just remember to test afterwards!
+
+You can also read more about trimming libraries [here](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming).
 
 ## How updates work
 

--- a/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
+++ b/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
@@ -71,8 +71,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-	<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-	<!--<PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" /> TODO 3.0 -->
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetSparkle\NetSparkle.csproj" />

--- a/src/NetSparkle/NetSparkle.csproj
+++ b/src/NetSparkle/NetSparkle.csproj
@@ -84,24 +84,19 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-	<!--<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />-->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />
-	<!--<PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" /> TODO: 3.0 -->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-	<!--<PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" /> TODO: 3.0 -->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-	<!--<PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" /> TODO: 3.0 -->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <!--<PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" /> TODO: 3.0 -->
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
-	  <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="nuget\**" />


### PR DESCRIPTION
This version of BouncyCastle is trimmable to a very reasonable size for end users. A test brings it down to less than 1 MB for NetSparkle. 

The app cast generator unfortunately will grow by a few MBs unless we find a way to trim BouncyCastle for it, but that's not a huge deal IMO as it ends up on a dev's machine rather than end-user machines.

* [x] Update BouncyCastle to 2.4.0
* [x] Write directions in README.md on trimming your application to save on file size

Closes #394
Closes #461 (use trimming instead which greatly reduces the file size and removes the need for us to move away from BouncyCastle)