### PR TITLE
Increase amount of LogWriter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Right now, we are compatible with version 11. If you need to make changes, you c
 
 Here are some things you can do to figure out how to get your app running:
 
-* Make sure you have enabled and debugged your application thoroughly. A great way to do this is to set `SparkleUpdater.LogWriter = new LogWriter(true)` and then watch your console output while debugging.
+* Make sure you have enabled and debugged your application thoroughly. A great way to do this is to set `SparkleUpdater.LogWriter = new LogWriter(LogWriterOutputMode.Console)` and then watch your console output while debugging.
 * Look at the NetSparkleUpdater samples by downloading this repo and running the samples. You can even try putting your app cast URL in there and using your public key to debug with the source code!
 * Ask for help in our [Gitter](https://gitter.im/NetSparkleUpdater/NetSparkle)
 * Post an issue and wait for someone to respond with assistance

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,6 +30,7 @@
   * Instead of a simple `bool` to control printing to `Trace.WriteLine` or `Console.WriteLine`, there is now a new enum, `NetSparkleUpdater.Enums.LogWriterOutputMode`, which you can use to control whether `LogWriter` outputs to `Console`, `Trace`, `Debug`, or to `None` (don't output at all).
   * Removed `PrintDiagnosticToConsole` property and replaced it with `OutputMode` of type `LogWriterOutputMode`.
   * The default print mode for `LogWriter` is still `Trace` by default, as it was in prior versions.
+  * By default, timestamps are now output along with the `Tag` and actual log item
 
 **Changes/Fixes**
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,6 +25,11 @@
 * `AssemblyReflectionAccessor` has been deprecated. Please use `AsmResolverAccessor` instead. (#587)
 * `AssemblyDiagnosticAccessor.AssemblyVersion` now returns `FileVersionInfo.GetVersionInfo(assemblyName).ProductVersion` rather than `FileVersionInfo.GetVersionInfo(assemblyName).FileVersion` so we can get semver versioning information
 * For ed25519 use, changed from BouncyCastle to Chaos.NaCl (large file size savings and we don't need all of BouncyCastle's features). You can verify its use and code online here: https://github.com/NetSparkleUpdater/Chaos.NaCl. Additionally, this package is available on NuGet for your own projects.
+* `LogWriter` has undergone several changes:
+  * `public static string tag = "netsparkle:";` has changed to `public string Tag { get; set; } = "netsparkle:";`
+  * Instead of a simple `bool` to control printing to `Trace.WriteLine` or `Console.WriteLine`, there is now a new enum, `NetSparkleUpdater.Enums.LogWriterOutputMode`, which you can use to control whether `LogWriter` outputs to `Console`, `Trace`, `Debug`, or to `None` (don't output at all).
+  * Removed `PrintDiagnosticToConsole` property and replaced it with `OutputMode` of type `LogWriterOutputMode`.
+  * The default print mode for `LogWriter` is still `Trace` by default, as it was in prior versions.
 
 **Changes/Fixes**
 

--- a/nuget/winformsnetframework/NetSparkleUpdater.UI.WinForms.NetFramework.nuspec
+++ b/nuget/winformsnetframework/NetSparkleUpdater.UI.WinForms.NetFramework.nuspec
@@ -27,5 +27,6 @@
  <files>
     <file src="..\..\README.md" target="" />
     <file src="..\..\LICENSE.md" target="" />
+    <file src="..\..\src\NetSparkle\ArtWork\software-update-available.png" target="" />
   </files>
 </package>

--- a/src/NetSparkle.Samples.Avalonia.MacOS/MainWindow.axaml.cs
+++ b/src/NetSparkle.Samples.Avalonia.MacOS/MainWindow.axaml.cs
@@ -3,8 +3,8 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
+using NetSparkleUpdater.Enums;
 using NetSparkleUpdater.SignatureVerifiers;
-using NetSparkleUpdater.UI.Avalonia;
 using System.IO;
 
 namespace NetSparkleUpdater.Samples.Avalonia
@@ -23,7 +23,7 @@ namespace NetSparkleUpdater.Samples.Avalonia
                 UIFactory = new NetSparkleUpdater.UI.Avalonia.UIFactory(Icon),
                 // Avalonia version doesn't support separate threads: https://github.com/AvaloniaUI/Avalonia/issues/3434#issuecomment-573446972
                 ShowsUIOnMainThread = true,
-                LogWriter = new LogWriter()
+                LogWriter = new LogWriter(LogWriterOutputMode.Console)
                 //UseNotificationToast = false // Avalonia version doesn't yet support notification toast messages
             };
             // TLS 1.2 required by GitHub (https://developer.github.com/changes/2018-02-01-weak-crypto-removal-notice/)

--- a/src/NetSparkle.Samples.Avalonia.MacOS/MainWindow.axaml.cs
+++ b/src/NetSparkle.Samples.Avalonia.MacOS/MainWindow.axaml.cs
@@ -23,7 +23,7 @@ namespace NetSparkleUpdater.Samples.Avalonia
                 UIFactory = new NetSparkleUpdater.UI.Avalonia.UIFactory(Icon),
                 // Avalonia version doesn't support separate threads: https://github.com/AvaloniaUI/Avalonia/issues/3434#issuecomment-573446972
                 ShowsUIOnMainThread = true,
-                LogWriter = new LogWriter(true)
+                LogWriter = new LogWriter()
                 //UseNotificationToast = false // Avalonia version doesn't yet support notification toast messages
             };
             // TLS 1.2 required by GitHub (https://developer.github.com/changes/2018-02-01-weak-crypto-removal-notice/)

--- a/src/NetSparkle.Samples.Avalonia.MacOSZip/MainWindow.axaml.cs
+++ b/src/NetSparkle.Samples.Avalonia.MacOSZip/MainWindow.axaml.cs
@@ -26,7 +26,7 @@ namespace NetSparkleUpdater.Samples.Avalonia
                 UIFactory = new NetSparkleUpdater.UI.Avalonia.UIFactory(Icon),
                 // Avalonia version doesn't support separate threads: https://github.com/AvaloniaUI/Avalonia/issues/3434#issuecomment-573446972
                 ShowsUIOnMainThread = true,
-                LogWriter = new LogWriter(true),
+                LogWriter = new LogWriter(),
                 RelaunchAfterUpdate = true,
                 //UseNotificationToast = false // Avalonia version doesn't yet support notification toast messages
 

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -1,13 +1,9 @@
 using NetSparkleUpdater.AppCastGenerator;
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.Crypto.Generators;
-using Org.BouncyCastle.Crypto.Parameters;
+using NetSparkleUpdater.Enums;
 using Org.BouncyCastle.Security;
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Runtime.CompilerServices;
 using Xunit;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
@@ -771,7 +767,7 @@ namespace NetSparkle.Tests.AppCastGenerator
                         new NetSparkleUpdater.SignatureVerifiers.Ed25519Checker(
                             NetSparkleUpdater.Enums.SecurityMode.Strict,
                             publicKeyString),
-                        new NetSparkleUpdater.LogWriter(true));
+                        new NetSparkleUpdater.LogWriter(LogWriterOutputMode.Console));
                 var didSucceed = appCastHandler.DownloadAndParse();
                 Assert.True(didSucceed);
                 var updates = appCastHandler.GetAvailableUpdates();
@@ -938,7 +934,7 @@ namespace NetSparkle.Tests.AppCastGenerator
                         new NetSparkleUpdater.SignatureVerifiers.Ed25519Checker(
                             NetSparkleUpdater.Enums.SecurityMode.Strict,
                             publicKeyString),
-                        new NetSparkleUpdater.LogWriter(true));
+                        new NetSparkleUpdater.LogWriter(LogWriterOutputMode.Console));
                 var didSucceed = appCastHandler.DownloadAndParse();
                 Assert.True(didSucceed);
                 var updates = appCastHandler.GetAvailableUpdates();

--- a/src/NetSparkle.Tools.AppCastGenerator/XMLAppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/XMLAppCastMaker.cs
@@ -1,4 +1,5 @@
 ﻿using NetSparkleUpdater.AppCastHandlers;
+using NetSparkleUpdater.Enums;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -56,7 +57,7 @@ namespace NetSparkleUpdater.AppCastGenerator
                     }
 
                     var docDescendants = doc.Descendants("item");
-                    var logWriter = new LogWriter(true);
+                    var logWriter = new LogWriter(LogWriterOutputMode.Console);
                     foreach (var item in docDescendants)
                     {
                         var currentItem = AppCastItem.Parse("", "", "/", item, logWriter);

--- a/src/NetSparkle/Enums/LogWriterOutputMode.cs
+++ b/src/NetSparkle/Enums/LogWriterOutputMode.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics;
+
+namespace NetSparkleUpdater.Enums
+{
+    /// <summary>
+    /// Output mode for the <seealso cref="LogWriter"/> class
+    /// </summary>
+    public enum LogWriterOutputMode
+    {
+        /// <summary>
+        /// Don't output anything
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Output to <seealso cref="Console.WriteLine(string, object[])"/>
+        /// </summary>
+        Console = 1,
+        /// <summary>
+        /// Output to <seealso cref="Trace.WriteLine(string)"/>
+        /// </summary>
+        Trace = 2,
+        /// <summary>
+        /// Output to <seealso cref="Debug.WriteLine(string, object[])"/>
+        /// </summary>
+        Debug = 3
+    }
+}

--- a/src/NetSparkle/LogWriter.cs
+++ b/src/NetSparkle/LogWriter.cs
@@ -1,66 +1,67 @@
 using NetSparkleUpdater.Enums;
 using NetSparkleUpdater.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NetSparkleUpdater
 {
     /// <summary>
-    /// A simple class to handle log information for NetSparkleUpdater.
+    /// A simple class to handle logging information.
     /// Make sure to do any setup for this class that you want
     /// to do before calling StartLoop on your <see cref="SparkleUpdater"/> object.
     /// </summary>
     public class LogWriter : ILogger
     {
         /// <summary>
-        /// Tag to show before any log statements
+        /// Tag to show before any log statements. Can be set to null.
         /// </summary>
-        public static string tag = "netsparkle:";
+        public string Tag { get; set; } = "netsparkle:";
 
         /// <summary>
-        /// Empty constructor -> sets PrintDiagnosticToConsole to false
+        /// Create a LogWriter that outputs to <seealso cref="Trace.WriteLine(string)"/> by default
         /// </summary>
         public LogWriter()
         {
-            PrintDiagnosticToConsole = false;
+            OutputMode = LogWriterOutputMode.Trace;
         }
 
         /// <summary>
-        /// LogWriter constructor that takes a bool to determine
-        /// the value for printDiagnosticToConsole
+        /// Create a LogWriter that outputs via the given LogWriterOutputMode mode
         /// </summary>
-        /// <param name="printDiagnosticToConsole">False to print to <seealso cref="Trace.WriteLine(string)"/>;
-        /// true to print to <seealso cref="Console.WriteLine(string)"/></param>
-        public LogWriter(bool printDiagnosticToConsole)
+        /// <param name="outputMode"><seealso cref="LogWriterOutputMode"/> for this LogWriter instance</param>;
+        public LogWriter(LogWriterOutputMode outputMode)
         {
-            PrintDiagnosticToConsole = printDiagnosticToConsole;
+            OutputMode = outputMode;
         }
 
         #region Properties
 
         /// <summary>
-        /// True if this class should print to <seealso cref="Console.WriteLine(string)"/>;
-        /// false if this object should print to <seealso cref="Trace.WriteLine(string)"/>.
-        /// Defaults to false.
+        /// <seealso cref="LogWriterOutputMode"/> for this LogWriter instance. Set to
+        /// <seealso cref="LogWriterOutputMode.None"/> to make this LogWriter output nothing.
         /// </summary>
-        public bool PrintDiagnosticToConsole { get; set; }
+        public LogWriterOutputMode OutputMode { get; set; }
 
         #endregion
         
         /// <inheritdoc/>
         public virtual void PrintMessage(string message, params object[] arguments)
         {
-            if (PrintDiagnosticToConsole)
+            switch (OutputMode)
             {
-                Console.WriteLine(tag + " " + message, arguments);
-            }
-            else
-            {
-                Trace.WriteLine(string.Format(tag + " " + message, arguments));
+                case LogWriterOutputMode.Console:
+                    Console.WriteLine(Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments);
+                    break;
+                case LogWriterOutputMode.Trace:
+                    Trace.WriteLine(string.Format(Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments));
+                    break;
+                case LogWriterOutputMode.Debug:
+                    Debug.WriteLine(Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments);
+                    break;
+                case LogWriterOutputMode.None:
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/src/NetSparkle/LogWriter.cs
+++ b/src/NetSparkle/LogWriter.cs
@@ -47,16 +47,17 @@ namespace NetSparkleUpdater
         /// <inheritdoc/>
         public virtual void PrintMessage(string message, params object[] arguments)
         {
+            var timestamp = string.Format("[{0:s}]", DateTime.Now);
             switch (OutputMode)
             {
                 case LogWriterOutputMode.Console:
-                    Console.WriteLine(Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments);
+                    Console.WriteLine(timestamp + " " + Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments);
                     break;
                 case LogWriterOutputMode.Trace:
-                    Trace.WriteLine(string.Format(Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments));
+                    Trace.WriteLine(string.Format(timestamp + " " + Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments));
                     break;
                 case LogWriterOutputMode.Debug:
-                    Debug.WriteLine(Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments);
+                    Debug.WriteLine(timestamp + " " + Tag + (string.IsNullOrWhiteSpace(Tag) ? "" : " ") + message, arguments);
                     break;
                 case LogWriterOutputMode.None:
                     break;


### PR DESCRIPTION
* `LogWriter` has undergone several changes:
  * `public static string tag = "netsparkle:";` has changed to `public string Tag { get; set; } = "netsparkle:";`
  * Instead of a simple `bool` to control printing to `Trace.WriteLine` or `Console.WriteLine`, there is now a new enum, `NetSparkleUpdater.Enums.LogWriterOutputMode`, which you can use to control whether `LogWriter` outputs to `Console`, `Trace`, `Debug`, or to `None` (don't output at all).
  * Removed `PrintDiagnosticToConsole` property and replaced it with `OutputMode` of type `LogWriterOutputMode`.
  * The default print mode for `LogWriter` is still `Trace` by default, as it was in prior versions.
  * Output of `LogWriter` now has timestamps

Closes #594 