### PR TITLE
Make AppCastItem compat with more OS strings

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -121,6 +121,7 @@
 * WinForms projects are now in the same project/run the same overall code.
 * `NetSparkle.UI.WinForms.NetFramework` now includes `System.Resources.Extensions`
 * Fixed WPF and Avalonia download progress windows not turning red on signature validation failure
+* `AppCastItem` operating system checks now use `.Contains` rather than `==`, allowing for OS strings like `macOS-arm64` rather than just `macOS`
 
 ## Updating from 0.X or 1.X to 2.X
 

--- a/src/NetSparkle.Tests/AppCastItemTests.cs
+++ b/src/NetSparkle.Tests/AppCastItemTests.cs
@@ -1,0 +1,48 @@
+﻿using NetSparkleUpdater;
+using NetSparkleUpdater.AppCastHandlers;
+using NetSparkleUpdater.Enums;
+using NetSparkleUpdater.SignatureVerifiers;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace NetSparkleUnitTests
+{
+    public class AppCastItemTests
+    {
+        [Theory]
+        [InlineData(null, true, false, false)]
+        [InlineData("win", true, false, false)]
+        [InlineData("windows", true, false, false)]
+        [InlineData("WINDOWS", true, false, false)]
+        [InlineData("WIndOWS", true, false, false)]
+        [InlineData("win-x64", true, false, false)]
+        [InlineData("win-arm", true, false, false)]
+        [InlineData("windows-arm", true, false, false)]
+        [InlineData("windows-x86", true, false, false)]
+        [InlineData("mac", false, true, false)]
+        [InlineData("macos", false, true, false)]
+        [InlineData("osx", false, true, false)]
+        [InlineData("mac-x86", false, true, false)]
+        [InlineData("macOS-x86", false, true, false)]
+        [InlineData("macos-arm", false, true, false)]
+        [InlineData("macos-x64", false, true, false)]
+        [InlineData("osx-x86", false, true, false)]
+        [InlineData("osx-arm", false, true, false)]
+        [InlineData("osx-x64", false, true, false)]
+        [InlineData("linux", false, false, true)]
+        [InlineData("linux-x64", false, false, true)]
+        [InlineData("linux-arm64", false, false, true)]
+        [InlineData("linux-arm", false, false, true)]
+        public void CanCheckOSProperly(string osString, bool isWindowsUpdate, bool isMacUpdate, bool isLinuxUpdate)
+        {
+            var item = new AppCastItem() { OperatingSystem = osString };
+            Assert.Equal(item.IsWindowsUpdate, isWindowsUpdate);
+            Assert.Equal(item.IsMacOSUpdate, isMacUpdate);
+            Assert.Equal(item.IsLinuxUpdate, isLinuxUpdate);
+        }
+    }
+}

--- a/src/NetSparkle/AppCastItem.cs
+++ b/src/NetSparkle/AppCastItem.cs
@@ -131,9 +131,9 @@ namespace NetSparkleUpdater
 
         /// <summary>
         /// True if this update is a windows update; false otherwise.
-        /// Acceptable OS strings are: "win" or "windows" (this is 
+        /// Acceptable OS strings contain "win" or "windows" (this is 
         /// checked with a case-insensitive check). If not specified,
-        /// assumed to be a Windows update.
+        /// the OS assumed to be a Windows update.
         /// </summary>
         [JsonIgnore]
         public bool IsWindowsUpdate
@@ -143,7 +143,7 @@ namespace NetSparkleUpdater
                 if (OperatingSystem != null)
                 {
                     var lowercasedOS = OperatingSystem.ToLower();
-                    if (lowercasedOS == "win" || lowercasedOS == "windows")
+                    if (lowercasedOS.Contains("win") || lowercasedOS.Contains("windows"))
                     {
                         return true;
                     }
@@ -155,9 +155,9 @@ namespace NetSparkleUpdater
 
         /// <summary>
         /// True if this update is a macOS update; false otherwise.
-        /// Acceptable OS strings are: "mac", "osx", or "macos" (this is 
+        /// Acceptable OS strings contain "mac", "osx", or "macos" (this is 
         /// checked with a case-insensitive check). If not specified,
-        /// assumed to be a Windows update.
+        /// the OS is assumed to be a Windows update.
         /// </summary>
         [JsonIgnore]
         public bool IsMacOSUpdate
@@ -167,7 +167,8 @@ namespace NetSparkleUpdater
                 if (OperatingSystem != null)
                 {
                     var lowercasedOS = OperatingSystem.ToLower();
-                    if (lowercasedOS == "mac" || lowercasedOS == "macos" || lowercasedOS == "osx")
+                    if (lowercasedOS.Contains("mac") || lowercasedOS.Contains("macos") || 
+                        lowercasedOS.Contains("osx"))
                     {
                         return true;
                     }
@@ -178,9 +179,9 @@ namespace NetSparkleUpdater
 
         /// <summary>
         /// True if this update is a macOS update; false otherwise.
-        /// Acceptable OS strings are: "linux" (this is 
+        /// Acceptable OS strings contain "linux" (this is 
         /// checked with a case-insensitive check). If not specified,
-        /// assumed to be a Linux update.
+        /// the OS is assumed to be a Windows update.
         /// </summary>
         [JsonIgnore]
         public bool IsLinuxUpdate
@@ -190,7 +191,7 @@ namespace NetSparkleUpdater
                 if (OperatingSystem != null)
                 {
                     var lowercasedOS = OperatingSystem.ToLower();
-                    if (lowercasedOS == "linux")
+                    if (lowercasedOS.Contains("linux"))
                     {
                         return true;
                     }


### PR DESCRIPTION
Use `.Contains` rather than exact string comparison so we can do things like "macOS-arm64"