### PR TITLE
Feature: Relative download paths, small fixes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -124,6 +124,7 @@
 * `AppCastItem` operating system checks now use `.Contains` rather than `==`, allowing for OS strings like `macOS-arm64` rather than just `macOS`
 * Add `TrustEverySSLConnection` to .NET Core `WebFileDownloader`
 * Fix `WebFileDownloader` not setting up an `HttpClientHandler` (was always auto-redirect'ing before despite setting `RedirectHandler`; now behaves more similarly to `WebRequestAppCastDataDownloader`)
+* Fixed `Unsafe` mode in DSA/ed25519 checkers still checking signatures if a signature existed
 
 ## Updating from 0.X or 1.X to 2.X
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -122,6 +122,8 @@
 * `NetSparkle.UI.WinForms.NetFramework` now includes `System.Resources.Extensions`
 * Fixed WPF and Avalonia download progress windows not turning red on signature validation failure
 * `AppCastItem` operating system checks now use `.Contains` rather than `==`, allowing for OS strings like `macOS-arm64` rather than just `macOS`
+* Add `TrustEverySSLConnection` to .NET Core `WebFileDownloader`
+* Fix `WebFileDownloader` not setting up an `HttpClientHandler` (was always auto-redirect'ing before despite setting `RedirectHandler`; now behaves more similarly to `WebRequestAppCastDataDownloader`)
 
 ## Updating from 0.X or 1.X to 2.X
 

--- a/src/NetSparkle.Samples.Avalonia.MacOS/CustomSparkleUpdater.cs
+++ b/src/NetSparkle.Samples.Avalonia.MacOS/CustomSparkleUpdater.cs
@@ -82,7 +82,7 @@ namespace NetSparkleUpdater.Samples.Avalonia
             }
             catch (InvalidDataException)
             {
-                UIFactory?.ShowUnknownInstallerFormatMessage(this, downloadFilePath);
+                UIFactory?.ShowUnknownInstallerFormatMessage(downloadFilePath);
                 return;
             }
 

--- a/src/NetSparkle/SignatureVerifiers/DSAChecker.cs
+++ b/src/NetSparkle/SignatureVerifiers/DSAChecker.cs
@@ -102,14 +102,8 @@ namespace NetSparkleUpdater.SignatureVerifiers
                 
                 case SecurityMode.Unsafe:
                     // always accept anything
-                    // If we don't have a signature, make sure to note this as "Unchecked" since we
-                    // didn't end up checking anything due to a lack of public key/signature
-                    if (!hasValidKeyInformation || !isSignatureValid)
-                    {
-                        result = ValidationResult.Unchecked;
-                        return false;
-                    }
-                    break;
+                    result = ValidationResult.Unchecked;
+                    return false;
 
                 case SecurityMode.OnlyVerifySoftwareDownloads:
                     // If we don't have a signature, make sure to note this as "Unchecked" since we

--- a/src/NetSparkle/SignatureVerifiers/Ed25519Checker.cs
+++ b/src/NetSparkle/SignatureVerifiers/Ed25519Checker.cs
@@ -120,14 +120,8 @@ namespace NetSparkleUpdater.SignatureVerifiers
                 
                 case SecurityMode.Unsafe:
                     // always accept anything
-                    // If we don't have a signature, make sure to note this as "Unchecked" since we
-                    // didn't end up checking anything due to a lack of public key/signature
-                    if (!HasValidKeyInformation() || string.IsNullOrWhiteSpace(signature))
-                    {
-                        result = ValidationResult.Unchecked;
-                        return false;
-                    }
-                    break;
+                    result = ValidationResult.Unchecked;
+                    return false;
 
                 case SecurityMode.OnlyVerifySoftwareDownloads:
                     // If we don't have a signature, make sure to note this as "Unchecked" since we

--- a/src/NetSparkle/SparkleUpdater.cs
+++ b/src/NetSparkle/SparkleUpdater.cs
@@ -864,6 +864,41 @@ namespace NetSparkleUpdater
                     }
                 }
 
+                if (string.IsNullOrWhiteSpace(filename))
+                {
+                    if (item.DownloadLink.StartsWith("..") || item.DownloadLink.StartsWith("."))
+                    {
+                        LogWriter?.PrintMessage("Trying for a relative path with download link of {0} and app cast URL of {1}", item.DownloadLink, AppCastUrl);
+                        var downloadUrl = Utilities.GetAbsoluteURL(item.DownloadLink, AppCastUrl);
+                        if (CheckServerFileName && UpdateDownloader != null)
+                        {
+                            try
+                            {
+                                var appCastItem = new AppCastItem() { DownloadLink = downloadUrl.ToString() };
+                                filename = await UpdateDownloader.RetrieveDestinationFileNameAsync(appCastItem);
+                            }
+                            catch (Exception)
+                            {
+                                // ignore
+                            }
+                        }
+
+                        if (string.IsNullOrWhiteSpace(filename))
+                        {
+                            // attempt to get download file name based on download link
+                            try
+                            {
+                                filename = Path.GetFileName(downloadUrl.LocalPath);
+                            }
+                            catch (UriFormatException)
+                            {
+                                // ignore
+                            }
+                        }
+                        LogWriter?.PrintMessage("After attempting relative path resolving, filename is {0}", filename ?? "");
+                    }
+                }
+
                 if (!string.IsNullOrWhiteSpace(filename))
                 {
                     string tmpPath = TmpDownloadFilePath == null || string.IsNullOrWhiteSpace(TmpDownloadFilePath) 


### PR DESCRIPTION
- Support relative paths in app cast download links, e.g. `../MyApp.exe`
- Fixed `Unsafe` mode in DSA/ed25519 checkers still checking signatures if a signature existed (4af1b6d)
- Add `TrustEverySSLConnection` to (.NET Core only for now) `WebFileDownloader`

Closes #399
