### PR TITLE
Fix app cast gen not working w/multiple dashes

### DIFF
--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -142,6 +142,7 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("appsetup2.10.1.exe"));
             
             // #623
+            Assert.Equal("1.3.0", AppCastMaker.GetVersionFromName("setup-something-1.3.0.dmg"));
             Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("app-setup-2.10.1.exe"));
             Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("my-app-setup-2.10.1.exe"));
             Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("my-app-setup-2.10.1.exe"));

--- a/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
+++ b/src/NetSparkle.Tests.AppCastGenerator/AppCastMakerTests.cs
@@ -140,6 +140,14 @@ namespace NetSparkle.Tests.AppCastGenerator
             Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("appsetup_2.10.1.exe"));
             Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("appsetup 2.10.1.exe"));
             Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("appsetup2.10.1.exe"));
+            
+            // #623
+            Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("app-setup-2.10.1.exe"));
+            Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("my-app-setup-2.10.1.exe"));
+            Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("my-app-setup-2.10.1.exe"));
+            Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("my-app-setup 2.10.1.exe"));
+            Assert.Equal("2.1", AppCastMaker.GetVersionFromName("my--app-setup-2.1.exe"));
+            Assert.Equal("2.10.1", AppCastMaker.GetVersionFromName("-my--app-setup-2.10.1.exe"));
 
             // Invalid semantic versions tests
             Assert.Null(AppCastMaker.GetVersionFromName("app 1.2.3-0123.txt"));

--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -127,10 +127,10 @@ namespace NetSparkleUpdater.AppCastGenerator
                 // if segment has text in it at the start and digits later, get rid of text and +/- symbol
                 if (Regex.IsMatch(segment, @"[a-zA-Z]") && Regex.IsMatch(segment, @"\d"))
                 {
-                    var match = Regex.Match(segment, @"[^+-]*[a-zA-Z][+-]?");
-                    if (match.Success)
+                    var match = Regex.Matches(segment, @"[^+-]*[a-zA-Z][+-]?");
+                    if (match.Count > 0)
                     {
-                        segment = segment.Substring(match.Index + match.Length);
+                        segment = segment.Substring(match.Last().Index + match.Last().Length);
                         lastVersionToCheck = true;
                     }
                 }

--- a/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/AppCastMaker.cs
@@ -137,7 +137,6 @@ namespace NetSparkleUpdater.AppCastGenerator
 
                 tempSegment = string.IsNullOrWhiteSpace(tempSegment) ? segment : segment + "." + tempSegment;
                 tempSegment = tempSegment.Trim('.');
-
                 if (ContainsValidVersionInfo(tempSegment))
                 {
                     lastValidVersionLeft = tempSegment;
@@ -207,7 +206,7 @@ namespace NetSparkleUpdater.AppCastGenerator
 
             // Handle a sampling of complex extensions and remove them if they exist
             List<string> extensionPatterns = [@"\.tar\.gz$", @"\.tar$", @"\.gz$", @"\.zip$", @"\.txt$", 
-            @"\.exe$", @"\.bin$", @"\.msi$", @"\.excel", @"\.mcdx", @"\.pdf", @"\.dll", @"\.ted"];
+            @"\.exe$", @"\.bin$", @"\.msi$", @"\.excel", @"\.mcdx", @"\.pdf", @"\.dll", @"\.ted", @"\.dmg"];
             // handle user-defined extensions
             if (extensions != null)
             {

--- a/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
+++ b/src/NetSparkle.Tools.AppCastGenerator/NetSparkle.Tools.AppCastGenerator.csproj
@@ -48,10 +48,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent />
-    <AssemblyVersion>2.8.1.0</AssemblyVersion>
-    <FileVersion>2.8.1.0</FileVersion>
+    <AssemblyVersion>2.8.2.0</AssemblyVersion>
+    <FileVersion>2.8.2.0</FileVersion>
     <PackageId>NetSparkleUpdater.Tools.AppCastGenerator</PackageId>
-    <Version>2.8.1</Version>
+    <Version>2.8.2</Version>
     <Authors>Deadpikle</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Just tweak the regex matching to get the last match for hyphen finding.

Closes #623