### PR TITLE
Support passing/overriding private and public key for --generate-signature option

### DIFF
--- a/src/NetSparkle.Tests/NetSparkle.Tests.csproj
+++ b/src/NetSparkle.Tests/NetSparkle.Tests.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{E50AC3A5-6C63-40D7-A4C4-9B359EFD5707}</ProjectGuid>
     <RootNamespace>NetSparkleUnitTests</RootNamespace>
     <AssemblyName>NetSparkleUnitTests</AssemblyName>
-    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -72,6 +72,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NetSparkle.Tools.AppCastGenerator\NetSparkle.Tools.AppCastGenerator.csproj" />
     <ProjectReference Include="..\NetSparkle\NetSparkle.csproj" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
     <PackageReference Include="AsmResolver.DotNet" Version="5.5.1" />

--- a/src/NetSparkle.Tests/OptionsTests.cs
+++ b/src/NetSparkle.Tests/OptionsTests.cs
@@ -1,0 +1,23 @@
+﻿using CommandLine;
+using NetSparkleUpdater.AppCastGenerator;
+using Xunit;
+
+namespace NetSparkleUnitTests;
+
+public class OptionsTests
+{
+    [Fact]
+    public void ParseArguments_KeysOverrideAndGenerateSignature_Compatibility()
+    {
+        var args = new[]
+        {
+            "--generate-signature", "binary.exe",
+            "--public-key-override", "TestPublicKey",
+            "--private-key-override", "TestPrivateKey"
+        };
+
+        var result = Parser.Default.ParseArguments<Options>(args);
+            
+        Assert.Empty(result.Errors);
+    }
+}

--- a/src/NetSparkle.Tools.AppCastGenerator/Options.cs
+++ b/src/NetSparkle.Tools.AppCastGenerator/Options.cs
@@ -81,12 +81,12 @@ namespace NetSparkleUpdater.AppCastGenerator
             Default = false)]
         public bool UseEd25519SignatureAttributeForXml { get; set; }
 
-        [Option("public-key-override", SetName = "local", Required = false, HelpText = "Public key override (ignores whatever is in the public key file) for signing binaries. This" +
+        [Option("public-key-override", Required = false, HelpText = "Public key override (ignores whatever is in the public key file) for signing binaries. This" +
             " overrides ALL other public keys set when verifying binaries, INCLUDING public key set via environment variables! " +
             "If not set, uses --key-path (if set) or the default SignatureManager location. Not used in --generate-keys or --export.", Default = "")]
         public string? PublicKeyOverride { get; set; }
 
-        [Option("private-key-override", SetName = "local", Required = false, HelpText = "Private key override (ignores whatever is in the private key file) for signing binaries. This" +
+        [Option("private-key-override", Required = false, HelpText = "Private key override (ignores whatever is in the private key file) for signing binaries. This" +
             " overrides ALL other private keys set when signing binaries, INCLUDING private key set via environment variables! " +
             "If not set, uses --key-path (if set) or the default SignatureManager location. Not used in --generate-keys or --export.", Default = "")]
         public string? PrivateKeyOverride { get; set; }


### PR DESCRIPTION
- removed SetName on PublicKeyOverride and PrivateKeyOverride
- created a Unit test to test compatibility of parameters