### PR TITLE
feat: add .NET 10.0 framework support to NetSparkle core library

### DIFF
--- a/src/NetSparkle/NetSparkle.csproj
+++ b/src/NetSparkle/NetSparkle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworksnet10.0;>net9.0;net8.0;net7.0;net6.0;netstandard2.0;net462</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.SparkleUpdater</PackageId>
     <Version>3.0.4</Version>


### PR DESCRIPTION
Added net10.0 to TargetFrameworks in NetSparkle.csproj to enable compatibility with .NET 10.0.

This enhancement allows developers using .NET 10.0 to utilize the NetSparkle software update framework in their applications.

Resolves #651