### PR TITLE
Migrate to Avalonia 12

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
    <PropertyGroup>
-	   <AvaloniaVersion>11.3.9</AvaloniaVersion>
+	   <AvaloniaVersion>12.0.2</AvaloniaVersion>
    </PropertyGroup>
 </Project>

--- a/src/NetSparkle.UI.Avalonia/CheckingForUpdatesWindow.axaml.cs
+++ b/src/NetSparkle.UI.Avalonia/CheckingForUpdatesWindow.axaml.cs
@@ -35,7 +35,7 @@ namespace NetSparkleUpdater.UI.Avalonia
         {
             this.InitializeComponent();
 #if DEBUG
-            this.AttachDevTools();
+            Application.Current?.AttachDeveloperTools();
 #endif
             Closing += CheckingForUpdatesWindow_Closing;
             var imageControl = this.FindControl<Image>("AppIcon");

--- a/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
+++ b/src/NetSparkle.UI.Avalonia/NetSparkle.UI.Avalonia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>NetSparkleUpdater.UI.Avalonia</PackageId>
     <Version>3.1.0-preview20260409001</Version>
@@ -91,10 +91,10 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.HtmlRenderer" Version="11.3.0" />
+    <PackageReference Include="Avalonia.HtmlRenderer" Version="12.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetSparkle.UI.Avalonia/UpdateAvailableWindow.axaml.cs
+++ b/src/NetSparkle.UI.Avalonia/UpdateAvailableWindow.axaml.cs
@@ -56,7 +56,7 @@ namespace NetSparkleUpdater.UI.Avalonia
                 imageControl.Source = iconBitmap;
             }
 #if DEBUG
-            this.AttachDevTools();
+            Application.Current?.AttachDeveloperTools();
 #endif
             DataContext = _dataContext = viewModel;
             _dataContext.ReleaseNotesDisplayer = this;


### PR DESCRIPTION
- Updated `AvaloniaVersion` to the latest Avalonia 12 build
- Dropped support for all .NET versions below .NET 8.0 for `NetSparkleUpdater.UI.Avalonia`
  - https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#net-support-updated
- Migrated from `Avalonia.Diagnostics` to `AvaloniaUI.DiagnosticsSupport`
  - https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#avaloniadiagnostics-package-removed

Closes #691